### PR TITLE
[PR-3] Add sector data fetching features

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -179,6 +179,7 @@ Excel / API  →    Ticker + Market   →   Sector (yF/SGX/CSV)  →  Sector wei
 | 5 | **Output & Reporting** | Generate JSON reports and/or upload results to Supabase |
 | 6 | **Historical Tracking** | Store and display sector weightage shifts across monthly iterations |
 | 7 | **Scheduling** | Automate monthly execution (cron, scheduler, or workflow trigger) |
+| 8 | **ETF Look-Through** | Replace dominant-sector approximation with proportional sector allocation for ETF holdings |
 
 ---
 
@@ -325,6 +326,25 @@ Expected contents:
 Acceptance criteria:
 - Scheduler fires on the configured cadence without manual intervention
 - Failures are surfaced through the notification channel, not silently swallowed
+
+---
+
+### PR 8 — ETF Look-Through Sector Weightage
+**Goal**: Replace the dominant-sector approximation with true proportional sector allocation for ETF holdings.
+
+Expected contents:
+- `src/models.py`: add `etf_sector_weights: dict[str, float]` field to `Holding` (populated when `etf_lookthrough=True`; keys are sector names; values are fractional weights summing ≤ 1.0)
+- `src/sector/fetcher.py`: `_resolve_etf` returns `tuple[dict[str, float], bool]` — full weight map + flag; cap look-through to top 20 holdings; `holding.sector` set to `"ETF Broad Market"` for all ETF holdings; remove TODO(PR 8) comment
+- `src/evaluation/calculator.py` (PR 4): distribute `holding_weight × etf_sector_weights[sector]` across sectors for ETF holdings with `etf_lookthrough=True`; assign full weight to `"ETF Broad Market"` when `etf_lookthrough=False`
+- `output/reporter.py` (PR 5): include `etf_sector_weights` dict in JSON snapshot `holdings` entries for ETF holdings
+- `tests/`: update `test_sector_fetcher.py` (assert `etf_sector_weights` dict), `test_calculator.py` (proportional ETF expansion), and `test_reporter.py` (assert `etf_sector_weights` in JSON output)
+
+Acceptance criteria:
+- ETF holdings with look-through yield `etf_sector_weights` dict summing ≤ 1.0
+- Portfolio sector percentages sum to 100% including proportional ETF expansion
+- ETF holdings without look-through data contribute 100% to `"ETF Broad Market"`
+- No live API calls during tests
+- Coverage ≥ 85%
 
 ---
 

--- a/data/sgx_sectors.csv
+++ b/data/sgx_sectors.csv
@@ -1,0 +1,31 @@
+ticker,sector
+C31.SI,REITs
+A17U.SI,REITs
+T82U.SI,REITs
+J69U.SI,REITs
+ME8U.SI,REITs
+N2IU.SI,REITs
+BUOU.SI,REITs
+K71U.SI,REITs
+M44U.SI,REITs
+AU8U.SI,REITs
+D05.SI,Financials
+O39.SI,Financials
+U11.SI,Financials
+Z74.SI,Communication Services
+ST.SI,Industrials
+C6L.SI,Industrials
+F34.SI,Consumer Staples
+BN4.SI,Industrials
+U96.SI,Energy
+V03.SI,Consumer Discretionary
+C09.SI,Utilities
+Y92.SI,Consumer Discretionary
+S58.SI,Industrials
+BS6.SI,Industrials
+G13.SI,Consumer Discretionary
+H78.SI,Industrials
+C52.SI,Industrials
+U14.SI,Real Estate (ex-REITs)
+S63.SI,Industrials
+D01.SI,Consumer Staples

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dev = [
     "pytest-asyncio==0.25.2",
     # Development Tools
     "mypy>=1.10",
+    "types-requests>=2.31",
     "pylint==4.0.3",
     "pandas-stubs>=2.2",
     "pre-commit>=4.5.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
     "pandas>=2.2",
     "openpyxl>=3.1",
     "ib-insync>=0.9",
+    "yfinance>=0.2",
 ]
 
 [dependency-groups]

--- a/src/ingestion/brokerage_client.py
+++ b/src/ingestion/brokerage_client.py
@@ -40,7 +40,7 @@ class IBKRBrokerageClient:
         ib = IB()  # type: ignore[no-untyped-call]
         try:
             ib.connect(self._host, self._port, self._client_id, self._connect_timeout)
-        except Exception as e:
+        except (OSError, TimeoutError) as e:
             raise ValidationError(
                 f"Failed to connect to IBKR at {self._host}:{self._port}: {e}"
             ) from e

--- a/src/ingestion/excel_parser.py
+++ b/src/ingestion/excel_parser.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import math
+import zipfile
 from pathlib import Path
 from typing import BinaryIO
 
@@ -21,7 +22,7 @@ class ExcelParser:
         """Parse the given Excel file and return a list of Holding objects."""
         try:
             df = pd.read_excel(source, engine="openpyxl")
-        except Exception as exc:
+        except (OSError, ValueError, zipfile.BadZipFile) as exc:
             raise ValidationError(f"Failed to read Excel file: {exc}") from exc
 
         # Normalize column names

--- a/src/models.py
+++ b/src/models.py
@@ -24,3 +24,5 @@ class Holding:
     quantity: float
     price: float
     currency: str
+    sector: str | None = None
+    etf_lookthrough: bool = False

--- a/src/sector/cache.py
+++ b/src/sector/cache.py
@@ -12,16 +12,16 @@ class SectorCache:
     """
 
     def __init__(self) -> None:
-        self._sectors: dict[str, str] = {}
+        self._holdings: dict[str, tuple[str, bool]] = {}  # ticker -> (sector, lookthrough)
         self.fx_rates: FxRates | None = None
 
-    def get_sector(self, ticker: str) -> str | None:
-        """Return the sector for the given ticker, or None if not found."""
-        return self._sectors.get(ticker)
+    def get_holding(self, ticker: str) -> tuple[str, bool] | None:
+        """Return cached (sector, etf_lookthrough) for the given ticker, or None if not found."""
+        return self._holdings.get(ticker)
 
-    def set_sector(self, ticker: str, sector: str) -> None:
-        """Cache the sector for the given ticker."""
-        self._sectors[ticker] = sector
+    def set_holding(self, ticker: str, sector: str, lookthrough: bool) -> None:
+        """Cache the resolved sector and etf_lookthrough for the given ticker."""
+        self._holdings[ticker] = (sector, lookthrough)
 
     def get_fx_rates(self) -> FxRates | None:
         """Return the cached FX rates, or None if not available."""
@@ -33,5 +33,5 @@ class SectorCache:
 
     def clear(self) -> None:
         """Clear all cached data."""
-        self._sectors.clear()
+        self._holdings.clear()
         self.fx_rates = None

--- a/src/sector/cache.py
+++ b/src/sector/cache.py
@@ -1,0 +1,37 @@
+"""In-memory cache for sector lookups and FX rates within a single run."""
+
+from src.sector.fx import FxRates
+
+
+class SectorCache:
+    """
+    Caches sector strings and FX rates for the duration of a single run.
+
+    Avoids redundant yFinance / SGX API calls when the same ticker
+    appears multiple times in the portfolio.
+    """
+
+    def __init__(self) -> None:
+        self._sectors: dict[str, str] = {}
+        self.fx_rates: FxRates | None = None
+
+    def get_sector(self, ticker: str) -> str | None:
+        """Return the sector for the given ticker, or None if not found."""
+        return self._sectors.get(ticker)
+
+    def set_sector(self, ticker: str, sector: str) -> None:
+        """Cache the sector for the given ticker."""
+        self._sectors[ticker] = sector
+
+    def get_fx_rates(self) -> FxRates | None:
+        """Return the cached FX rates, or None if not available."""
+        return self.fx_rates
+
+    def set_fx_rates(self, rates: FxRates) -> None:
+        """Cache the FX rates."""
+        self.fx_rates = rates
+
+    def clear(self) -> None:
+        """Clear all cached data."""
+        self._sectors.clear()
+        self.fx_rates = None

--- a/src/sector/cache.py
+++ b/src/sector/cache.py
@@ -13,7 +13,7 @@ class SectorCache:
 
     def __init__(self) -> None:
         self._holdings: dict[str, tuple[str, bool]] = {}  # ticker -> (sector, lookthrough)
-        self.fx_rates: FxRates | None = None
+        self._fx_rates: FxRates | None = None
 
     def get_holding(self, ticker: str) -> tuple[str, bool] | None:
         """Return cached (sector, etf_lookthrough) for the given ticker, or None if not found."""
@@ -25,13 +25,13 @@ class SectorCache:
 
     def get_fx_rates(self) -> FxRates | None:
         """Return the cached FX rates, or None if not available."""
-        return self.fx_rates
+        return self._fx_rates
 
     def set_fx_rates(self, rates: FxRates) -> None:
         """Cache the FX rates."""
-        self.fx_rates = rates
+        self._fx_rates = rates
 
     def clear(self) -> None:
         """Clear all cached data."""
         self._holdings.clear()
-        self.fx_rates = None
+        self._fx_rates = None

--- a/src/sector/fetcher.py
+++ b/src/sector/fetcher.py
@@ -20,7 +20,7 @@ from typing import Any
 import requests  # type: ignore[import-untyped]
 import yfinance as yf  # type: ignore[import-untyped]
 
-from src.models import Holding
+from src.models import Holding, detect_market
 from src.sector.cache import SectorCache
 
 YFINANCE_SECTOR_MAP: dict[str, str] = {
@@ -41,6 +41,16 @@ _REIT_OVERRIDE_SECTORS = {"Financials", "Real Estate (ex-REITs)"}
 _CSV_PATH = Path(__file__).parent.parent.parent / "data" / "sgx_sectors.csv"
 _SGX_API_URL = "https://api.sgx.com/securities/v1.1"
 _SGX_API_TIMEOUT = 5  # seconds
+_CSV_SECTOR_SYNONYMS: dict[str, str] = {
+    "Telecommunications": "Communication Services",
+    "Telecom": "Communication Services",
+    "Finance": "Financials",
+    "Banking": "Financials",
+    "Industrial": "Industrials",
+    "Real Estate Investment Trust": "REITs",
+    "Property": "Real Estate (ex-REITs)",
+    "Consumer": "Consumer Discretionary",
+}
 
 
 class SectorFetcher:
@@ -101,20 +111,24 @@ class SectorFetcher:
                 weight = float(row.get("holdingPercent", 0.0))
                 if weight <= 0:
                     continue
-                constituent_sector = self._resolve_equity(
-                    Holding(
-                        ticker=str(constituent_ticker),
-                        market="US",
-                        quantity=0,
-                        price=0,
-                        currency="USD",
-                    )
+
+                ticker_str = str(constituent_ticker)
+                market = detect_market(ticker_str)
+                currency = "SGD" if market == "SG" else ("GBP" if market == "UK" else "USD")
+                constituent_holding = Holding(
+                    ticker=ticker_str,
+                    market=market,
+                    quantity=0,
+                    price=0,
+                    currency=currency,
                 )
+                constituent_sector, _ = self._resolve(constituent_holding)
                 weights[constituent_sector] = weights.get(constituent_sector, 0.0) + weight
 
             if not weights:
                 return "ETF Broad Market", False
 
+            # TODO(PR 8): Implement proportional ETF sector weight distribution (top 20 holdings)
             # Return dominant sector (highest combined weight)
             dominant = max(weights, key=lambda s: weights[s])
             return dominant, True
@@ -170,7 +184,14 @@ class SectorFetcher:
             if response.status_code != 200:
                 return None
             data: Any = response.json()
-            raw_sector: str = data.get("data", {}).get("items", [{}])[0].get("category", "")
+            item: dict[str, Any] = data.get("data", {}).get("items", [{}])[0]
+            raw_sector: str = item.get("category", "")
+            name: str = item.get("name", "") + " " + item.get("description", "")
+
+            # REIT check before taxonomy map - SGX categories are not GICS-aligned
+            if "REIT" in raw_sector.upper() or "REIT" in name.upper():
+                return "REITs"
+
             return YFINANCE_SECTOR_MAP.get(raw_sector)
         except (OSError, ValueError, KeyError, IndexError):
             return None
@@ -184,7 +205,9 @@ class SectorFetcher:
         try:
             with _CSV_PATH.open(newline="", encoding="utf-8") as fh:
                 for row in csv.DictReader(fh):
-                    mapping[row["ticker"].strip().upper()] = row["sector"].strip()
+                    raw = row["sector"].strip()
+                    canonical = _CSV_SECTOR_SYNONYMS.get(raw, raw)
+                    mapping[row["ticker"].strip().upper()] = canonical
         except (OSError, KeyError, csv.Error):
             pass
         self._csv_data = mapping

--- a/src/sector/fetcher.py
+++ b/src/sector/fetcher.py
@@ -62,9 +62,9 @@ class SectorFetcher:
     # Resolution router method
     def _resolve(self, holding: Holding) -> tuple[str, bool]:
         """Return (sector, etf_lookthrough) for the given holding."""
-        cached = self._cache.get_sector(holding.ticker)
+        cached = self._cache.get_holding(holding.ticker)
         if cached is not None:
-            return cached, holding.etf_lookthrough
+            return cached
 
         if self._is_etf(holding.ticker):
             sector, lookthrough = self._resolve_etf(holding.ticker)
@@ -72,7 +72,7 @@ class SectorFetcher:
             sector = self._resolve_equity(holding)
             lookthrough = False
 
-        self._cache.set_sector(holding.ticker, sector)
+        self._cache.set_holding(holding.ticker, sector, lookthrough)
         return sector, lookthrough
 
     # ETF resolution method
@@ -126,26 +126,35 @@ class SectorFetcher:
     def _resolve_equity(self, holding: Holding) -> str:
         """Resolve sector for a non-ETF holding."""
         if holding.market in ("US", "UK", "EU", "JP"):
-            sector = self._yfinance_sector(holding.ticker)
+            sector, _ = self._yfinance_sector(holding.ticker)
             return sector if sector else "Unclassified"
 
-        # SG: 4-layer fallback
-        sector = (
-            self._yfinance_sector(holding.ticker)
-            or self._sgx_api_sector(holding.ticker)
-            or self._sgx_csv_sector(holding.ticker)
-            or "Unclassified"
-        )
-        return self._apply_reit_override(holding.ticker, sector)
+        if holding.market == "SG":
+            # SG: 4-layer fallback
+            sector, long_name = self._yfinance_sector(holding.ticker)
+            if not sector:
+                sector = (
+                    self._sgx_api_sector(holding.ticker)
+                    or self._sgx_csv_sector(holding.ticker)
+                    or "Unclassified"
+                )
+                long_name = ""  # longName only available from yFinance layer
+            return self._apply_reit_override(holding.ticker, sector, long_name)
+
+        # Unknown market: yFinance only, no SGX fallback or REIT override
+        sector, _ = self._yfinance_sector(holding.ticker)
+        return sector if sector else "Unclassified"
 
     # Layer 1 - yFinance
-    def _yfinance_sector(self, ticker: str) -> str | None:
-        """Return normalzied taxonomy sector from yFinance, or None."""
+    def _yfinance_sector(self, ticker: str) -> tuple[str | None, str]:
+        """Return normalized taxonomy sector from yFinance, or None."""
         try:
-            raw = yf.Ticker(ticker).info.get("sector", "")
-            return YFINANCE_SECTOR_MAP.get(str(raw))
+            info = yf.Ticker(ticker).info
+            raw = info.get("sector", "")
+            name = str(info.get("longName", ""))
+            return YFINANCE_SECTOR_MAP.get(str(raw)), name
         except (OSError, KeyError, TypeError, AttributeError):
-            return None
+            return None, ""
 
     # Layer 2 - SGX public API
     def _sgx_api_sector(self, ticker: str) -> str | None:
@@ -186,12 +195,11 @@ class SectorFetcher:
         return self._load_csv().get(ticker.upper())
 
     # REIT override (SG only)
-    def _apply_reit_override(self, ticker: str, sector: str) -> str:
+    def _apply_reit_override(self, ticker: str, sector: str, long_name: str = "") -> str:
         """
         Reclassify to 'REITs' if:
           - ticker contains 'REIT' (case-insensitive), OR
-          - resolved sector is Financials or Real Estate (ex-REITs)
-            and security appears to be a REIT by name
+          - longName indicates REIT
 
         This rule applies only to SG holdings (caller's responsibility).
         """
@@ -199,10 +207,7 @@ class SectorFetcher:
             return "REITs"
         if sector in _REIT_OVERRIDE_SECTORS:
             # Additional name-based check via yFinance longName
-            try:
-                name: str = yf.Ticker(ticker).info.get("longName", "")
-                if "REIT" in name.upper() or "REAL ESTATE INVEST" in name.upper():
-                    return "REITs"
-            except (OSError, KeyError, TypeError, AttributeError):
-                pass
+            upper_name = long_name.upper()
+            if "REIT" in upper_name or "REAL ESTATE INVEST" in upper_name:
+                return "REITs"
         return sector

--- a/src/sector/fetcher.py
+++ b/src/sector/fetcher.py
@@ -17,7 +17,7 @@ from dataclasses import replace
 from pathlib import Path
 from typing import Any
 
-import requests  # type: ignore[import-untyped]
+import requests
 import yfinance as yf  # type: ignore[import-untyped]
 
 from src.models import Holding, detect_market
@@ -49,6 +49,11 @@ _CSV_SECTOR_SYNONYMS: dict[str, str] = {
     "Industrial": "Industrials",
     "Real Estate Investment Trust": "REITs",
     "Property": "Real Estate (ex-REITs)",
+    # SGX CSV uses "Consumer Goods" and "Consumer Services"; "Consumer" alone is a
+    # conservative fallback assumed to mean Discretionary - verify against the
+    # bundled CSV Before relying on this mapping
+    "Consumer Goods": "Consumer Discretionary",
+    "Consumer Services": "Consumer Discretionary",
     "Consumer": "Consumer Discretionary",
 }
 
@@ -193,7 +198,7 @@ class SectorFetcher:
                 return "REITs"
 
             return YFINANCE_SECTOR_MAP.get(raw_sector)
-        except (OSError, ValueError, KeyError, IndexError):
+        except (OSError, ValueError, KeyError, IndexError, requests.exceptions.RequestException):
             return None
 
     # Layer 3 - Static CSV

--- a/src/sector/fetcher.py
+++ b/src/sector/fetcher.py
@@ -1,0 +1,208 @@
+"""Sector classification for portfolio holdings.
+
+Resolution priority:
+  US/UK/EU/JP equities : yFinance only
+  SG equities          : yFinance → SGX public API → static CSV → Unclassified
+  ETFs                 : look-through (proportional) → ETF Broad Market (fallback)
+
+After any resolution, the SG REIT override is applied:
+  if market == "SG" and (ticker contains "REIT" or sector is Financials/Real Estate)
+  → reclassify to "REITs"
+"""
+
+from __future__ import annotations
+
+import csv
+from dataclasses import replace
+from pathlib import Path
+from typing import Any
+
+import requests  # type: ignore[import-untyped]
+import yfinance as yf  # type: ignore[import-untyped]
+
+from src.models import Holding
+from src.sector.cache import SectorCache
+
+YFINANCE_SECTOR_MAP: dict[str, str] = {
+    "Technology": "Technology",
+    "Healthcare": "Healthcare",
+    "Financial Services": "Financials",
+    "Consumer Cyclical": "Consumer Discretionary",
+    "Consumer Defensive": "Consumer Staples",
+    "Industrials": "Industrials",
+    "Energy": "Energy",
+    "Basic Materials": "Materials",
+    "Utilities": "Utilities",
+    "Communication Services": "Communication Services",
+    "Real Estate": "Real Estate (ex-REITs)",
+}
+
+_REIT_OVERRIDE_SECTORS = {"Financials", "Real Estate (ex-REITs)"}
+_CSV_PATH = Path(__file__).parent.parent.parent / "data" / "sgx_sectors.csv"
+_SGX_API_URL = "https://api.sgx.com/securities/v1.1"
+_SGX_API_TIMEOUT = 5  # seconds
+
+
+class SectorFetcher:
+    """Enriches a list of Holdings with sector classifications."""
+
+    def __init__(self, cache: SectorCache) -> None:
+        self._cache = cache
+        self._csv_data: dict[str, str] | None = None  # loaded once on first use
+
+    # Public API method
+    def enrich(self, holdings: list[Holding]) -> list[Holding]:
+        """Return new Holding instances with sector and etf_lookthrough set."""
+        enriched: list[Holding] = []
+        for holding in holdings:
+            sector, lookthrough = self._resolve(holding)
+            enriched.append(replace(holding, sector=sector, etf_lookthrough=lookthrough))
+        return enriched
+
+    # Resolution router method
+    def _resolve(self, holding: Holding) -> tuple[str, bool]:
+        """Return (sector, etf_lookthrough) for the given holding."""
+        cached = self._cache.get_sector(holding.ticker)
+        if cached is not None:
+            return cached, holding.etf_lookthrough
+
+        if self._is_etf(holding.ticker):
+            sector, lookthrough = self._resolve_etf(holding.ticker)
+        else:
+            sector = self._resolve_equity(holding)
+            lookthrough = False
+
+        self._cache.set_sector(holding.ticker, sector)
+        return sector, lookthrough
+
+    # ETF resolution method
+    def _is_etf(self, ticker: str) -> bool:
+        """Return True if yFinance identifies this ticker as an ETF."""
+        try:
+            info = yf.Ticker(ticker).fast_info
+            return str(info.get("quote_type", "")).upper() == "ETF"
+        except (OSError, KeyError, TypeError, AttributeError):
+            return False
+
+    def _resolve_etf(self, ticker: str) -> tuple[str, bool]:
+        """
+        Attempt ETF look-through via yFinance fund holdings.
+
+        Returns (sector, etf_lookthrough=True) on success,
+        ("ETF Broad Market", False) if constituent data is unavailable.
+        """
+        try:
+            fund_holdings = yf.Ticker(ticker).funds_data.top_holdings
+            if fund_holdings is None or fund_holdings.empty:
+                return "ETF Broad Market", False
+
+            weights: dict[str, float] = {}
+            for constituent_ticker, row in fund_holdings.iterrows():
+                weight = float(row.get("holdingPercent", 0.0))
+                if weight <= 0:
+                    continue
+                constituent_sector = self._resolve_equity(
+                    Holding(
+                        ticker=str(constituent_ticker),
+                        market="US",
+                        quantity=0,
+                        price=0,
+                        currency="USD",
+                    )
+                )
+                weights[constituent_sector] = weights.get(constituent_sector, 0.0) + weight
+
+            if not weights:
+                return "ETF Broad Market", False
+
+            # Return dominant sector (highest combined weight)
+            dominant = max(weights, key=lambda s: weights[s])
+            return dominant, True
+
+        except (OSError, AttributeError, TypeError, ValueError, KeyError):
+            return "ETF Broad Market", False
+
+    # Equity resolution method
+    def _resolve_equity(self, holding: Holding) -> str:
+        """Resolve sector for a non-ETF holding."""
+        if holding.market in ("US", "UK", "EU", "JP"):
+            sector = self._yfinance_sector(holding.ticker)
+            return sector if sector else "Unclassified"
+
+        # SG: 4-layer fallback
+        sector = (
+            self._yfinance_sector(holding.ticker)
+            or self._sgx_api_sector(holding.ticker)
+            or self._sgx_csv_sector(holding.ticker)
+            or "Unclassified"
+        )
+        return self._apply_reit_override(holding.ticker, sector)
+
+    # Layer 1 - yFinance
+    def _yfinance_sector(self, ticker: str) -> str | None:
+        """Return normalzied taxonomy sector from yFinance, or None."""
+        try:
+            raw = yf.Ticker(ticker).info.get("sector", "")
+            return YFINANCE_SECTOR_MAP.get(str(raw))
+        except (OSError, KeyError, TypeError, AttributeError):
+            return None
+
+    # Layer 2 - SGX public API
+    def _sgx_api_sector(self, ticker: str) -> str | None:
+        """Query SGX public API for sector. Returns normalized string or None."""
+        try:
+            # Strip .SI suffix for the API query
+            code = ticker.upper().removesuffix(".SI")
+            response = requests.get(
+                _SGX_API_URL,
+                params={"code": code},
+                timeout=_SGX_API_TIMEOUT,
+            )
+            if response.status_code != 200:
+                return None
+            data: Any = response.json()
+            raw_sector: str = data.get("data", {}).get("items", [{}])[0].get("category", "")
+            return YFINANCE_SECTOR_MAP.get(raw_sector)
+        except (OSError, ValueError, KeyError, IndexError):
+            return None
+
+    # Layer 3 - Static CSV
+    def _load_csv(self) -> dict[str, str]:
+        """Load and cache SGX sector CSV. Returns {ticker: sector}."""
+        if self._csv_data is not None:
+            return self._csv_data
+        mapping: dict[str, str] = {}
+        try:
+            with _CSV_PATH.open(newline="", encoding="utf-8") as fh:
+                for row in csv.DictReader(fh):
+                    mapping[row["ticker"].strip().upper()] = row["sector"].strip()
+        except (OSError, KeyError, csv.Error):
+            pass
+        self._csv_data = mapping
+        return self._csv_data
+
+    def _sgx_csv_sector(self, ticker: str) -> str | None:
+        """Look up ticker in bundled SGX CSV. Returns sector string or None."""
+        return self._load_csv().get(ticker.upper())
+
+    # REIT override (SG only)
+    def _apply_reit_override(self, ticker: str, sector: str) -> str:
+        """
+        Reclassify to 'REITs' if:
+          - ticker contains 'REIT' (case-insensitive), OR
+          - resolved sector is Financials or Real Estate (ex-REITs)
+            and security appears to be a REIT by name
+
+        This rule applies only to SG holdings (caller's responsibility).
+        """
+        if "REIT" in ticker.upper():
+            return "REITs"
+        if sector in _REIT_OVERRIDE_SECTORS:
+            # Additional name-based check via yFinance longName
+            try:
+                name: str = yf.Ticker(ticker).info.get("longName", "")
+                if "REIT" in name.upper() or "REAL ESTATE INVEST" in name.upper():
+                    return "REITs"
+            except (OSError, KeyError, TypeError, AttributeError):
+                pass
+        return sector

--- a/src/sector/fx.py
+++ b/src/sector/fx.py
@@ -38,7 +38,7 @@ class FxFetcher:
                 if price is None or price <= 0:
                     raise ValueError(f"Invalid price for {symbol}: {price}")
                 rates[field] = float(price)
-            except Exception:
+            except (OSError, KeyError, TypeError, ValueError):
                 missing.append(symbol)
 
         if missing:

--- a/src/sector/fx.py
+++ b/src/sector/fx.py
@@ -1,0 +1,47 @@
+"""FX rates and fetcher for external API (yahoo finance)."""
+
+from dataclasses import dataclass
+
+import yfinance as yf  # type: ignore[import-untyped]
+
+from src.exceptions import ValidationError
+
+
+@dataclass(frozen=True)
+class FxRates:
+    """Represents FX rates relative to SGD."""
+
+    usdsgd: float
+    gbpsgd: float
+    eursgd: float
+    jpysgd: float
+
+
+class FxFetcher:
+    """Fetches live FX rates from yFinance."""
+
+    _SYMBOLS: dict[str, str] = {
+        "usdsgd": "USDSGD=X",
+        "gbpsgd": "GBPSGD=X",
+        "eursgd": "EURSGD=X",
+        "jpysgd": "JPYSGD=X",
+    }
+
+    def fetch(self) -> FxRates:
+        """Fetch FX rates from yFinance and return as FxRates dataclass."""
+        rates: dict[str, float] = {}
+        missing: list[str] = []
+
+        for field, symbol in self._SYMBOLS.items():
+            try:
+                price = yf.Ticker(symbol).fast_info["last_price"]
+                if price is None or price <= 0:
+                    raise ValueError(f"Invalid price for {symbol}: {price}")
+                rates[field] = float(price)
+            except Exception:
+                missing.append(symbol)
+
+        if missing:
+            raise ValidationError(f"Failed to fetch FX rates for: {', '.join(missing)}")
+
+        return FxRates(**rates)

--- a/tests/test_fx.py
+++ b/tests/test_fx.py
@@ -105,7 +105,7 @@ class TestFxFetcher:
         with pytest.raises(ValidationError, match="JPYSGD=X"):
             FxFetcher().fetch()
 
-    def test_fetch_raises_listing_both_when_all_missing(self, mocker: MockerFixture) -> None:
+    def test_fetch_raises_listing_all_when_all_missing(self, mocker: MockerFixture) -> None:
         """Error message names every missing rate when all fail."""
         mocker.patch("src.sector.fx.yf.Ticker", side_effect=OSError("timeout"))
 
@@ -140,15 +140,15 @@ class TestFxFetcher:
 class TestSectorCache:
     """Tests for SectorCache class."""
 
-    def test_get_sector_returns_none_when_not_cached(self) -> None:
-        """get_sector returns None if sector not in cache."""
-        assert SectorCache().get_sector("AAPL") is None
+    def test_get_holding_returns_none_when_not_cached(self) -> None:
+        """get_holding returns None if sector not in cache."""
+        assert SectorCache().get_holding("AAPL") is None
 
-    def test_set_and_get_sector_round_trips(self) -> None:
-        """set_sector followed by get_sector returns the same value."""
+    def test_set_and_get_holding_round_trips(self) -> None:
+        """set_holding followed by get_holding returns the same value."""
         cache = SectorCache()
-        cache.set_sector("AAPL", "Technology")
-        assert cache.get_sector("AAPL") == "Technology"
+        cache.set_holding("AAPL", "Technology", False)
+        assert cache.get_holding("AAPL") == ("Technology", False)
 
     def test_get_fx_rates_returns_none_when_not_set(self) -> None:
         """get_fx_rates returns None if rates not set."""
@@ -164,23 +164,23 @@ class TestSectorCache:
     def test_clear_removes_sectors_and_fx_rates(self) -> None:
         """clear removes all cached sectors and FX rates."""
         cache = SectorCache()
-        cache.set_sector("AAPL", "Technology")
+        cache.set_holding("AAPL", "Technology", False)
         cache.set_fx_rates(FxRates(usdsgd=1.34, gbpsgd=1.23, eursgd=1.56, jpysgd=0.0091))
         cache.clear()
-        assert cache.get_sector("AAPL") is None
+        assert cache.get_holding("AAPL") is None
         assert cache.get_fx_rates() is None
 
     def test_different_tickers_cached_independently(self) -> None:
         """Sectors for different tickers are stored and retrieved independently."""
         cache = SectorCache()
-        cache.set_sector("AAPL", "Technology")
-        cache.set_sector("D05.SI", "Financials")
-        assert cache.get_sector("AAPL") == "Technology"
-        assert cache.get_sector("D05.SI") == "Financials"
+        cache.set_holding("AAPL", "Technology", False)
+        cache.set_holding("D05.SI", "Financials", False)
+        assert cache.get_holding("AAPL") == ("Technology", False)
+        assert cache.get_holding("D05.SI") == ("Financials", False)
 
     def test_overwrite_cached_sector(self) -> None:
         """Setting a sector for a ticker that already has one overwrites it."""
         cache = SectorCache()
-        cache.set_sector("AAPL", "Technology")
-        cache.set_sector("AAPL", "Consumer Discretionary")
-        assert cache.get_sector("AAPL") == "Consumer Discretionary"
+        cache.set_holding("AAPL", "Technology", False)
+        cache.set_holding("AAPL", "Consumer Discretionary", False)
+        assert cache.get_holding("AAPL") == ("Consumer Discretionary", False)

--- a/tests/test_fx.py
+++ b/tests/test_fx.py
@@ -1,0 +1,186 @@
+"""Tests for FxFetcher and SectorCache."""
+
+from typing import Any
+
+import pytest
+from pytest_mock import MockerFixture
+
+from src.exceptions import ValidationError
+from src.sector.cache import SectorCache
+from src.sector.fx import FxFetcher, FxRates
+
+
+class TestFxFetcher:
+    """Tests for FxFetcher class."""
+
+    def test_fetch_returns_fx_rates(self, mocker: MockerFixture) -> None:
+        """Successful fetch returns FxRates with correct values."""
+
+        def mock_fast_info(symbol: str) -> Any:
+            ticker = mocker.MagicMock()
+            ticker.fast_info = {
+                "last_price": 1.34
+                if "USD" in symbol
+                else 1.23
+                if "GBP" in symbol
+                else 1.56
+                if "EUR" in symbol
+                else 0.0091
+            }
+            return ticker
+
+        mocker.patch("src.sector.fx.yf.Ticker", side_effect=mock_fast_info)
+        rates = FxFetcher().fetch()
+
+        assert rates.usdsgd == pytest.approx(1.34)
+        assert rates.gbpsgd == pytest.approx(1.23)
+        assert rates.eursgd == pytest.approx(1.56)
+        assert rates.jpysgd == pytest.approx(0.0091)
+
+    def test_fetch_raises_when_usd_rate_missing(self, mocker: MockerFixture) -> None:
+        """ValidationError raised when USDSGD cannot be retrieved."""
+
+        def mock_fast_info(symbol: str) -> Any:
+            if "USD" in symbol:
+                raise RuntimeError("API error")
+            ticker = mocker.MagicMock()
+            ticker.fast_info = {
+                "last_price": 1.23 if "GBP" in symbol else 1.56 if "EUR" in symbol else 0.0091
+            }
+            return ticker
+
+        mocker.patch("src.sector.fx.yf.Ticker", side_effect=mock_fast_info)
+
+        with pytest.raises(ValidationError, match="USDSGD=X"):
+            FxFetcher().fetch()
+
+    def test_fetch_raises_when_gbp_rate_missing(self, mocker: MockerFixture) -> None:
+        """ValidationError raised when GBPSGD cannot be retrieved."""
+
+        def mock_fast_info(symbol: str) -> Any:
+            if "GBP" in symbol:
+                raise RuntimeError("API error")
+            ticker = mocker.MagicMock()
+            ticker.fast_info = {
+                "last_price": 1.34 if "USD" in symbol else 1.56 if "EUR" in symbol else 0.0091
+            }
+            return ticker
+
+        mocker.patch("src.sector.fx.yf.Ticker", side_effect=mock_fast_info)
+
+        with pytest.raises(ValidationError, match="GBPSGD=X"):
+            FxFetcher().fetch()
+
+    def test_fetch_raises_when_eur_rate_missing(self, mocker: MockerFixture) -> None:
+        """ValidationError raised when EURSGD cannot be retrieved."""
+
+        def mock_fast_info(symbol: str) -> Any:
+            if "EUR" in symbol:
+                raise RuntimeError("API error")
+            ticker = mocker.MagicMock()
+            ticker.fast_info = {
+                "last_price": 1.34 if "USD" in symbol else 1.23 if "GBP" in symbol else 0.0091
+            }
+            return ticker
+
+        mocker.patch("src.sector.fx.yf.Ticker", side_effect=mock_fast_info)
+
+        with pytest.raises(ValidationError, match="EURSGD=X"):
+            FxFetcher().fetch()
+
+    def test_fetch_raises_when_jpy_rate_missing(self, mocker: MockerFixture) -> None:
+        """ValidationError raised when JPYSGD cannot be retrieved."""
+
+        def mock_fast_info(symbol: str) -> Any:
+            if "JPY" in symbol:
+                raise RuntimeError("API error")
+            ticker = mocker.MagicMock()
+            ticker.fast_info = {
+                "last_price": 1.34 if "USD" in symbol else 1.23 if "GBP" in symbol else 1.56
+            }
+            return ticker
+
+        mocker.patch("src.sector.fx.yf.Ticker", side_effect=mock_fast_info)
+
+        with pytest.raises(ValidationError, match="JPYSGD=X"):
+            FxFetcher().fetch()
+
+    def test_fetch_raises_listing_both_when_all_missing(self, mocker: MockerFixture) -> None:
+        """Error message names every missing rate when all fail."""
+        mocker.patch("src.sector.fx.yf.Ticker", side_effect=RuntimeError("timeout"))
+
+        with pytest.raises(ValidationError) as exc_info:
+            FxFetcher().fetch()
+
+        msg = str(exc_info.value)
+        assert "USDSGD=X" in msg
+        assert "GBPSGD=X" in msg
+        assert "EURSGD=X" in msg
+        assert "JPYSGD=X" in msg
+
+    def test_fetch_raises_on_zero_rate(self, mocker: MockerFixture) -> None:
+        """A zero rate is treated as unavailable."""
+        ticker = mocker.MagicMock()
+        ticker.fast_info = {"last_price": 0}
+        mocker.patch("src.sector.fx.yf.Ticker", return_value=ticker)
+
+        with pytest.raises(ValidationError):
+            FxFetcher().fetch()
+
+    def test_fetch_raises_on_none_rate(self, mocker: MockerFixture) -> None:
+        """A None rate is treated as unavailable."""
+        ticker = mocker.MagicMock()
+        ticker.fast_info = {"last_price": None}
+        mocker.patch("src.sector.fx.yf.Ticker", return_value=ticker)
+
+        with pytest.raises(ValidationError):
+            FxFetcher().fetch()
+
+
+class TestSectorCache:
+    """Tests for SectorCache class."""
+
+    def test_get_sector_returns_none_when_not_cached(self) -> None:
+        """get_sector returns None if sector not in cache."""
+        assert SectorCache().get_sector("AAPL") is None
+
+    def test_set_and_get_sector_round_trips(self) -> None:
+        """set_sector followed by get_sector returns the same value."""
+        cache = SectorCache()
+        cache.set_sector("AAPL", "Technology")
+        assert cache.get_sector("AAPL") == "Technology"
+
+    def test_get_fx_rates_returns_none_when_not_set(self) -> None:
+        """get_fx_rates returns None if rates not set."""
+        assert SectorCache().get_fx_rates() is None
+
+    def test_set_and_get_fx_rates_round_trips(self) -> None:
+        """set_fx_rates followed by get_fx_rates returns the same values."""
+        cache = SectorCache()
+        rates = FxRates(usdsgd=1.34, gbpsgd=1.23, eursgd=1.56, jpysgd=0.0091)
+        cache.set_fx_rates(rates)
+        assert cache.get_fx_rates() == rates
+
+    def test_clear_removes_sectors_and_fx_rates(self) -> None:
+        """clear removes all cached sectors and FX rates."""
+        cache = SectorCache()
+        cache.set_sector("AAPL", "Technology")
+        cache.set_fx_rates(FxRates(usdsgd=1.34, gbpsgd=1.23, eursgd=1.56, jpysgd=0.0091))
+        cache.clear()
+        assert cache.get_sector("AAPL") is None
+        assert cache.get_fx_rates() is None
+
+    def test_different_tickers_cached_independently(self) -> None:
+        """Sectors for different tickers are stored and retrieved independently."""
+        cache = SectorCache()
+        cache.set_sector("AAPL", "Technology")
+        cache.set_sector("D05.SI", "Financials")
+        assert cache.get_sector("AAPL") == "Technology"
+        assert cache.get_sector("D05.SI") == "Financials"
+
+    def test_overwrite_cached_sector(self) -> None:
+        """Setting a sector for a ticker that already has one overwrites it."""
+        cache = SectorCache()
+        cache.set_sector("AAPL", "Technology")
+        cache.set_sector("AAPL", "Consumer Discretionary")
+        assert cache.get_sector("AAPL") == "Consumer Discretionary"

--- a/tests/test_fx.py
+++ b/tests/test_fx.py
@@ -42,7 +42,7 @@ class TestFxFetcher:
 
         def mock_fast_info(symbol: str) -> Any:
             if "USD" in symbol:
-                raise RuntimeError("API error")
+                raise OSError("API error")
             ticker = mocker.MagicMock()
             ticker.fast_info = {
                 "last_price": 1.23 if "GBP" in symbol else 1.56 if "EUR" in symbol else 0.0091
@@ -59,7 +59,7 @@ class TestFxFetcher:
 
         def mock_fast_info(symbol: str) -> Any:
             if "GBP" in symbol:
-                raise RuntimeError("API error")
+                raise OSError("API error")
             ticker = mocker.MagicMock()
             ticker.fast_info = {
                 "last_price": 1.34 if "USD" in symbol else 1.56 if "EUR" in symbol else 0.0091
@@ -76,7 +76,7 @@ class TestFxFetcher:
 
         def mock_fast_info(symbol: str) -> Any:
             if "EUR" in symbol:
-                raise RuntimeError("API error")
+                raise OSError("API error")
             ticker = mocker.MagicMock()
             ticker.fast_info = {
                 "last_price": 1.34 if "USD" in symbol else 1.23 if "GBP" in symbol else 0.0091
@@ -93,7 +93,7 @@ class TestFxFetcher:
 
         def mock_fast_info(symbol: str) -> Any:
             if "JPY" in symbol:
-                raise RuntimeError("API error")
+                raise OSError("API error")
             ticker = mocker.MagicMock()
             ticker.fast_info = {
                 "last_price": 1.34 if "USD" in symbol else 1.23 if "GBP" in symbol else 1.56
@@ -107,7 +107,7 @@ class TestFxFetcher:
 
     def test_fetch_raises_listing_both_when_all_missing(self, mocker: MockerFixture) -> None:
         """Error message names every missing rate when all fail."""
-        mocker.patch("src.sector.fx.yf.Ticker", side_effect=RuntimeError("timeout"))
+        mocker.patch("src.sector.fx.yf.Ticker", side_effect=OSError("timeout"))
 
         with pytest.raises(ValidationError) as exc_info:
             FxFetcher().fetch()

--- a/tests/test_fx.py
+++ b/tests/test_fx.py
@@ -17,16 +17,10 @@ class TestFxFetcher:
         """Successful fetch returns FxRates with correct values."""
 
         def mock_fast_info(symbol: str) -> Any:
+            prices = {"USD": 1.34, "GBP": 1.23, "EUR": 1.56, "JPY": 0.0091}
             ticker = mocker.MagicMock()
-            ticker.fast_info = {
-                "last_price": 1.34
-                if "USD" in symbol
-                else 1.23
-                if "GBP" in symbol
-                else 1.56
-                if "EUR" in symbol
-                else 0.0091
-            }
+            key = next((k for k in prices if k in symbol), None)
+            ticker.fast_info = {"last_price": prices[key] if key else 0.0}
             return ticker
 
         mocker.patch("src.sector.fx.yf.Ticker", side_effect=mock_fast_info)
@@ -43,10 +37,10 @@ class TestFxFetcher:
         def mock_fast_info(symbol: str) -> Any:
             if "USD" in symbol:
                 raise OSError("API error")
+            prices = {"USD": 1.34, "GBP": 1.23, "EUR": 1.56, "JPY": 0.0091}
             ticker = mocker.MagicMock()
-            ticker.fast_info = {
-                "last_price": 1.23 if "GBP" in symbol else 1.56 if "EUR" in symbol else 0.0091
-            }
+            key = next((k for k in prices if k in symbol), None)
+            ticker.fast_info = {"last price": prices[key] if key else 0.0}
             return ticker
 
         mocker.patch("src.sector.fx.yf.Ticker", side_effect=mock_fast_info)
@@ -60,10 +54,10 @@ class TestFxFetcher:
         def mock_fast_info(symbol: str) -> Any:
             if "GBP" in symbol:
                 raise OSError("API error")
+            prices = {"USD": 1.34, "GBP": 1.23, "EUR": 1.56, "JPY": 0.0091}
             ticker = mocker.MagicMock()
-            ticker.fast_info = {
-                "last_price": 1.34 if "USD" in symbol else 1.56 if "EUR" in symbol else 0.0091
-            }
+            key = next((k for k in prices if k in symbol), None)
+            ticker.fast_info = {"last price": prices[key] if key else 0.0}
             return ticker
 
         mocker.patch("src.sector.fx.yf.Ticker", side_effect=mock_fast_info)
@@ -77,10 +71,10 @@ class TestFxFetcher:
         def mock_fast_info(symbol: str) -> Any:
             if "EUR" in symbol:
                 raise OSError("API error")
+            prices = {"USD": 1.34, "GBP": 1.23, "EUR": 1.56, "JPY": 0.0091}
             ticker = mocker.MagicMock()
-            ticker.fast_info = {
-                "last_price": 1.34 if "USD" in symbol else 1.23 if "GBP" in symbol else 0.0091
-            }
+            key = next((k for k in prices if k in symbol), None)
+            ticker.fast_info = {"last price": prices[key] if key else 0.0}
             return ticker
 
         mocker.patch("src.sector.fx.yf.Ticker", side_effect=mock_fast_info)
@@ -94,10 +88,10 @@ class TestFxFetcher:
         def mock_fast_info(symbol: str) -> Any:
             if "JPY" in symbol:
                 raise OSError("API error")
+            prices = {"USD": 1.34, "GBP": 1.23, "EUR": 1.56, "JPY": 0.0091}
             ticker = mocker.MagicMock()
-            ticker.fast_info = {
-                "last_price": 1.34 if "USD" in symbol else 1.23 if "GBP" in symbol else 1.56
-            }
+            key = next((k for k in prices if k in symbol), None)
+            ticker.fast_info = {"last price": prices[key] if key else 0.0}
             return ticker
 
         mocker.patch("src.sector.fx.yf.Ticker", side_effect=mock_fast_info)

--- a/tests/test_sector_fetcher.py
+++ b/tests/test_sector_fetcher.py
@@ -163,7 +163,6 @@ class TestReitOverride:
 class TestEtfLookthrough:
     """Test class for ETF look-through"""
 
-    # TODO: Change etf-lookthrough to calculate top 20 fund holding sector %
     def test_etf_with_holdings_use_lookthrough(self, mocker: MockerFixture) -> None:
         """ETF with available fund holdings -> etf_lookthrough=True, dominant sector."""
         df = pd.DataFrame({"holdingPercent": [0.07, 0.06]}, index=["AAPL", "MSFT"])
@@ -228,7 +227,7 @@ class TestCaching:
 
         # First AAPL: _is_etf + _yfinance_sector = 2 calls max
         # Second AAPL: cache hit -> 0 additional calls
-        assert yf_patch.call_count <= 2
+        assert yf_patch.call_count == 2
 
     def test_cache_populated_after_enrich(self, mocker: MockerFixture) -> None:
         """Sector is stored in cache after enrich."""

--- a/tests/test_sector_fetcher.py
+++ b/tests/test_sector_fetcher.py
@@ -1,0 +1,327 @@
+"""Tests for SectorFetcher - all external calls mocked."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pandas as pd
+import yfinance as yf  # type: ignore[import-untyped]
+from pytest_mock import MockerFixture
+
+from src.models import Holding
+from src.sector.cache import SectorCache
+from src.sector.fetcher import YFINANCE_SECTOR_MAP, SectorFetcher
+
+
+# Helper function
+def _make_holding(
+    ticker: str = "AAPL",
+    market: str = "US",
+    currency: str = "USD",
+) -> Holding:
+    return Holding(ticker=ticker, market=market, quantity=10, price=100.0, currency=currency)
+
+
+def _fetcher(cache: SectorCache | None = None) -> SectorFetcher:
+    return SectorFetcher(cache or SectorCache())
+
+
+# US / UK / EU / JP Equity via yFinance
+# Currently only test US & UK
+class TestUsUkEquities:
+    """Test class for US & UK equities"""
+
+    def test_us_ticker_mapped_from_yfinance(self, mocker: MockerFixture) -> None:
+        """US ticker resolved via yFinance and mapped to taxonomy."""
+        _mock_yf_info(mocker, "AAPL", sector="Technology", quote_type="EQUITY")
+        result = _fetcher().enrich([_make_holding("AAPL", "US")])
+        assert result[0].sector == "Technology"
+        assert result[0].etf_lookthrough is False
+
+    def test_uk_ticker_mapped_from_yfinance(self, mocker: MockerFixture) -> None:
+        """UK ticker resolved via yFinance and mapped to taxonomy"""
+        _mock_yf_info(mocker, "LLOY.L", sector="Financial Services", quote_type="EQUITY")
+        result = _fetcher().enrich([_make_holding("LLOY.L", "UK", "GBP")])
+        assert result[0].sector == "Financials"
+
+    def test_unknown_yfinance_sector_maps_to_unclassified(self, mocker: MockerFixture) -> None:
+        """yFinance sector string not in taxonomy map -> Unclassified."""
+        _mock_yf_info(mocker, "AAPL", sector="Widget", quote_type="EQUITY")
+        result = _fetcher().enrich([_make_holding("AAPL", "US")])
+        assert result[0].sector == "Unclassified"
+
+    def test_yfinance_raises_returns_unclassified(self, mocker: MockerFixture) -> None:
+        """yFinance exception -> Unclassified, no exception raised."""
+        mocker.patch("src.sector.fetcher.yf.Ticker", side_effect=OSError("timeout"))
+        result = _fetcher().enrich([_make_holding("AAPL", "US")])
+        assert result[0].sector == "Unclassified"
+        assert result[0].etf_lookthrough is False
+
+
+# SGX fallback chain
+
+
+class TestSgxFallbackChain:
+    """Test class for SGX fallback chain"""
+
+    def test_layer1_yfinance_resolves_sg_ticker(self, mocker: MockerFixture) -> None:
+        """Layer 1: .SI ticker resolved via yFinance"""
+        _mock_yf_info(mocker, "D05.SI", sector="Financial Services", quote_type="EQUITY")
+        result = _fetcher().enrich([_make_holding("D05.SI", "SG", "SGD")])
+        assert result[0].sector == "Financials"
+
+    def test_layer2_sgx_api_used_when_yfinance_fails(self, mocker: MockerFixture) -> None:
+        """Layer 2: SGX API used when yFinance returns no sector."""
+        _mock_yf_info(mocker, "X99.SI", sector=None, quote_type="EQUITY")
+        _mock_sgx_api(mocker, "Financial Services")
+        result = _fetcher().enrich([_make_holding("X99.SI", "SG", "SGD")])
+        assert result[0].sector == "Financials"
+
+    def test_layer3_csv_used_when_api_fails(self, mocker: MockerFixture) -> None:
+        """Layer 3: CSV used when yFinance and SGX API both fail."""
+        _mock_yf_info(mocker, "C31.SI", sector=None, quote_type="EQUITY")
+        _mock_sgx_api(mocker, None)
+        mocker.patch.object(SectorFetcher, "_load_csv", return_value={"C31.SI": "REITs"})
+        result = _fetcher().enrich([_make_holding("C31.SI", "SG", "SGD")])
+        assert result[0].sector == "REITs"
+
+    def test_layer4_unclassified_when_all_fail(self, mocker: MockerFixture) -> None:
+        """Layer 4: Unclassified when yFinance, SGX API, and CSV all fail."""
+        _mock_yf_info(mocker, "Z99.SI", sector=None, quote_type="EQUITY")
+        _mock_sgx_api(mocker, None)
+        mocker.patch.object(SectorFetcher, "_load_csv", return_value={})
+        result = _fetcher().enrich([_make_holding("Z99.SI", "SG", "SGD")])
+        assert result[0].sector == "Unclassified"
+
+    def test_sgx_api_non_200_falls_through_to_csv(self, mocker: MockerFixture) -> None:
+        """Non-200 SGX API response treated as layer 2 miss."""
+        _mock_yf_info(mocker, "X99.SI", sector=None, quote_type="EQUITY")
+        mock_resp = MagicMock()
+        mock_resp.status_code = 503
+        mocker.patch("src.sector.fetcher.requests.get", return_value=mock_resp)
+        mocker.patch.object(SectorFetcher, "_load_csv", return_value={"X99.SI": "Industrials"})
+        result = _fetcher().enrich([_make_holding("X99.SI", "SG", "SGD")])
+        assert result[0].sector == "Industrials"
+
+    def test_sgx_api_timeout_falls_through_to_csv(self, mocker: MockerFixture) -> None:
+        """SGX API timeout treated as layer 2 miss."""
+        _mock_yf_info(mocker, "X99.SI", sector=None, quote_type="EQUITY")
+        mocker.patch("src.sector.fetcher.requests.get", side_effect=TimeoutError)
+        mocker.patch.object(SectorFetcher, "_load_csv", return_value={"X99.SI": "Industrials"})
+        result = _fetcher().enrich([_make_holding("X99.SI", "SG", "SGD")])
+        assert result[0].sector == "Industrials"
+
+
+# REIT override
+
+
+class TestReitOverride:
+    """Test class for REIT category override"""
+
+    def test_reit_in_ticker_name_overrides_financials(self, mocker: MockerFixture) -> None:
+        """'REIT' in ticker -> REITs regardless of yFinance classification."""
+        _mock_yf_info(mocker, "CREIT.SI", sector="Financial Services", quote_type="EQUITY")
+        result = _fetcher().enrich([_make_holding("CREIT.SI", "SG", "SGD")])
+        assert result[0].sector == "REITs"
+
+    def test_reit_name_in_long_name_overrides_real_estate(self, mocker: MockerFixture) -> None:
+        """yFinance longName contains 'REIT' -> REITs overrides Real Estate."""
+        _mock_yf_info(
+            mocker,
+            "C31.SI",
+            sector="Real Estate",
+            quote_type="EQUITY",
+            long_name="CapitaLand Integrated Commercial REIT",
+        )
+        result = _fetcher().enrich([_make_holding("C31.SI", "SG", "SGD")])
+        assert result[0].sector == "REITs"
+
+    def test_sg_financials_without_reit_indicators_not_overridden(
+        self, mocker: MockerFixture
+    ) -> None:
+        """SG Financials holding with no REIT indicators stays Financials."""
+        _mock_yf_info(
+            mocker,
+            "D05.SI",
+            sector="Financial Services",
+            quote_type="EQUITY",
+            long_name="DBS Group Holdings Ltd",
+        )
+        result = _fetcher().enrich([_make_holding("D05.SI", "SG", "SGD")])
+        assert result[0].sector == "Financials"
+
+    def test_us_reit_ticker_not_overridden(self, mocker: MockerFixture) -> None:
+        """REIT override does NOT apply to US market holdings."""
+        _mock_yf_info(mocker, "VNQ", sector="Real Estate", quote_type="EQUITY")
+        result = _fetcher().enrich([_make_holding("VNQ", "US")])
+        assert result[0].sector == "Real Estate (ex-REITs)"
+
+
+# ETF look-through
+
+
+class TestEtfLookthrough:
+    """Test class for ETF look-through"""
+
+    # TODO: Change etf-lookthrough to calculate top 20 fund holding sector %
+    def test_etf_with_holdings_use_lookthrough(self, mocker: MockerFixture) -> None:
+        """ETF with available fund holdings -> etf_lookthrough=True, dominant sector."""
+        df = pd.DataFrame({"holdingPercent": [0.07, 0.06]}, index=["AAPL", "MSFT"])
+
+        voo_mock = MagicMock()
+        voo_mock.fast_info = {"quote_type": "ETF"}
+        voo_mock.funds_data.top_holdings = df
+
+        equity_mock = MagicMock()
+        equity_mock.fast_info = {"quote_type": "EQUITY"}
+        equity_mock.info = {"sector": "Technology", "longName": ""}
+
+        def side_effect(ticker: str) -> Any:
+            return voo_mock if ticker == "VOO" else equity_mock
+
+        mocker.patch("src.sector.fetcher.yf.Ticker", side_effect=side_effect)
+        result = _fetcher().enrich([_make_holding("VOO", "US")])
+
+        assert result[0].etf_lookthrough is True
+        assert result[0].sector == "Technology"
+
+    def test_etf_without_holdings_falls_back_to_broad_market(self, mocker: MockerFixture) -> None:
+        """ETF with no fund holdings data -> ETF Broad Market, etf_lookthrough=False."""
+        _mock_yf_etf(mocker, "VOO", top_holdings=None)
+        result = _fetcher().enrich([_make_holding("VOO", "US")])
+        assert result[0].sector == "ETF Broad Market"
+        assert result[0].etf_lookthrough is False
+
+    def test_etf_lookthrough_error_falls_back_to_broad_market(self, mocker: MockerFixture) -> None:
+        """Exception during look-through -> ETF Broad Market, no exception raised."""
+        ticker_mock = MagicMock()
+        ticker_mock.fast_info = {"quote_type": "ETF"}
+        ticker_mock.funds_data.top_holdings = None
+        mocker.patch("src.sector.fetcher.yf.Ticker", return_value=ticker_mock)
+        result = _fetcher().enrich([_make_holding("VOO", "US")])
+        assert result[0].sector == "ETF Broad Market"
+        assert result[0].etf_lookthrough is False
+
+    def test_non_etf_has_lookthrough_false(self, mocker: MockerFixture) -> None:
+        """Non-ETF holding always has etf_lookthrough=False."""
+        _mock_yf_info(mocker, "AAPL", sector="Technology", quote_type="EQUITY")
+        result = _fetcher().enrich([_make_holding("AAPL", "US")])
+        assert result[0].etf_lookthrough is False
+
+
+# Caching behavior
+
+
+class TestCaching:
+    """Test class for caching"""
+
+    def test_second_call_for_same_ticker_hits_cache(self, mocker: MockerFixture) -> None:
+        """yFinance called only once when same ticker appears twice."""
+        _mock_yf_info(mocker, "AAPL", sector="Technology", quote_type="EQUITY")
+        spy = mocker.patch("src.sector.fetcher.yf.Ticker", wraps=yf.Ticker)
+        cache = SectorCache()
+        fetcher = SectorFetcher(cache)
+        fetcher.enrich([_make_holding("AAPL"), _make_holding("AAPL")])
+        # yf.Ticker should be called for ETF check + sector lookup on first hit only
+        assert spy.call_count <= 2  # ETF check + info - not doubled
+
+    def test_cache_populated_after_enrich(self, mocker: MockerFixture) -> None:
+        """Sector is stored in cache after enrich."""
+        _mock_yf_info(mocker, "AAPL", sector="Technology", quote_type="EQUITY")
+        cache = SectorCache()
+        SectorFetcher(cache).enrich([_make_holding("AAPL")])
+        assert cache.get_sector("AAPL") == "Technology"
+
+
+# Edge cases
+
+
+class TestEdgeCases:
+    """Test class for edge cases"""
+
+    def test_empty_holdings_returns_empty_list(self) -> None:
+        """Empty holdings should return empty list."""
+        result = _fetcher().enrich([])
+        assert not result
+
+    def test_input_holdings_not_mutated(self, mocker: MockerFixture) -> None:
+        """enrich() returns new Holding instances; originals unchanged."""
+        _mock_yf_info(mocker, "AAPL", sector="Technology", quote_type="EQUITY")
+        original = _make_holding("AAPL", "US")
+        result = _fetcher().enrich([original])
+        assert original.sector is None
+        assert result[0].sector == "Technology"
+
+    def test_all_taxonomy_sectors_covered(self) -> None:
+        """Spot-check that key yFianance sector strings are mapped."""
+        assert YFINANCE_SECTOR_MAP["Technology"] == "Technology"
+        assert YFINANCE_SECTOR_MAP["Financial Services"] == "Financials"
+        assert YFINANCE_SECTOR_MAP["Real Estate"] == "Real Estate (ex-REITs)"
+        assert YFINANCE_SECTOR_MAP["Consumer Cyclical"] == "Consumer Discretionary"
+
+
+# Mock helpers
+
+
+def _mock_yf_info(
+    mocker: MockerFixture,
+    ticker: str,
+    *,
+    sector: str | None,
+    quote_type: str,
+    long_name: str = "",
+) -> Any:
+    ticker_mock = MagicMock()
+    ticker_mock.fast_info = {"quote_type": quote_type}
+    ticker_mock.info = {
+        "sector": sector or "",
+        "longName": long_name,
+        "quoteType": quote_type,
+    }
+    mocker.patch(
+        "src.sector.fetcher.yf.Ticker",
+        side_effect=lambda t: (
+            ticker_mock
+            if t == ticker
+            else MagicMock(fast_info={"quote_type": "EQUITY"}, info={"sector": "", "longName": ""})
+        ),
+    )
+    return ticker_mock
+
+
+def _mock_yf_etf(
+    mocker: MockerFixture, ticker: str, *, top_holdings: dict[str, float] | None
+) -> Any:
+    ticker_mock = MagicMock()
+    ticker_mock.fast_info = {"quote_type": "ETF"}
+    if top_holdings is not None:
+        df = pd.DataFrame(
+            {"holdingPercent": list(top_holdings.values())}, index=list(top_holdings.keys())
+        )
+        ticker_mock.funds_data.top_holdings = df
+    else:
+        ticker_mock.funds_data.top_holdings = None
+    mocker.patch(
+        "src.sector.fetcher.yf.Ticker",
+        side_effect=lambda t: (
+            ticker_mock
+            if t == ticker
+            else MagicMock(
+                fast_info={"quote_type": "EQUITY"}, funds_data=MagicMock(top_holdings=None)
+            )
+        ),
+    )
+    return ticker_mock
+
+
+def _mock_sgx_api(mocker: MockerFixture, sector: str | None) -> Any:
+    mock_resp = MagicMock()
+    if sector is not None:
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"data": {"items": [{"category": sector}]}}
+    else:
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"data": {"items": [{}]}}
+    mocker.patch("src.sector.fetcher.requests.get", return_value=mock_resp)
+    return mock_resp

--- a/tests/test_sector_fetcher.py
+++ b/tests/test_sector_fetcher.py
@@ -6,7 +6,6 @@ from typing import Any
 from unittest.mock import MagicMock
 
 import pandas as pd
-import yfinance as yf  # type: ignore[import-untyped]
 from pytest_mock import MockerFixture
 
 from src.models import Holding
@@ -218,20 +217,25 @@ class TestCaching:
 
     def test_second_call_for_same_ticker_hits_cache(self, mocker: MockerFixture) -> None:
         """yFinance called only once when same ticker appears twice."""
-        _mock_yf_info(mocker, "AAPL", sector="Technology", quote_type="EQUITY")
-        spy = mocker.patch("src.sector.fetcher.yf.Ticker", wraps=yf.Ticker)
+        ticker_mock = MagicMock()
+        ticker_mock.fast_info = {"quote_type": "EQUITY"}
+        ticker_mock.info = {"sector": "Technology", "longName": ""}
+
+        yf_patch = mocker.patch("src.sector.fetcher.yf.Ticker", return_value=ticker_mock)
+
         cache = SectorCache()
-        fetcher = SectorFetcher(cache)
-        fetcher.enrich([_make_holding("AAPL"), _make_holding("AAPL")])
-        # yf.Ticker should be called for ETF check + sector lookup on first hit only
-        assert spy.call_count <= 2  # ETF check + info - not doubled
+        SectorFetcher(cache).enrich([_make_holding("AAPL"), _make_holding("AAPL")])
+
+        # First AAPL: _is_etf + _yfinance_sector = 2 calls max
+        # Second AAPL: cache hit -> 0 additional calls
+        assert yf_patch.call_count <= 2
 
     def test_cache_populated_after_enrich(self, mocker: MockerFixture) -> None:
         """Sector is stored in cache after enrich."""
         _mock_yf_info(mocker, "AAPL", sector="Technology", quote_type="EQUITY")
         cache = SectorCache()
         SectorFetcher(cache).enrich([_make_holding("AAPL")])
-        assert cache.get_sector("AAPL") == "Technology"
+        assert cache.get_holding("AAPL") == ("Technology", False)
 
 
 # Edge cases
@@ -254,7 +258,7 @@ class TestEdgeCases:
         assert result[0].sector == "Technology"
 
     def test_all_taxonomy_sectors_covered(self) -> None:
-        """Spot-check that key yFianance sector strings are mapped."""
+        """Spot-check that key yFinance sector strings are mapped."""
         assert YFINANCE_SECTOR_MAP["Technology"] == "Technology"
         assert YFINANCE_SECTOR_MAP["Financial Services"] == "Financials"
         assert YFINANCE_SECTOR_MAP["Real Estate"] == "Real Estate (ex-REITs)"

--- a/tests/test_sector_fetcher.py
+++ b/tests/test_sector_fetcher.py
@@ -6,6 +6,7 @@ from typing import Any
 from unittest.mock import MagicMock
 
 import pandas as pd
+import requests
 from pytest_mock import MockerFixture
 
 from src.models import Holding
@@ -106,7 +107,7 @@ class TestSgxFallbackChain:
     def test_sgx_api_timeout_falls_through_to_csv(self, mocker: MockerFixture) -> None:
         """SGX API timeout treated as layer 2 miss."""
         _mock_yf_info(mocker, "X99.SI", sector=None, quote_type="EQUITY")
-        mocker.patch("src.sector.fetcher.requests.get", side_effect=TimeoutError)
+        mocker.patch("src.sector.fetcher.requests.get", side_effect=requests.exceptions.Timeout)
         mocker.patch.object(SectorFetcher, "_load_csv", return_value={"X99.SI": "Industrials"})
         result = _fetcher().enrich([_make_holding("X99.SI", "SG", "SGD")])
         assert result[0].sector == "Industrials"

--- a/uv.lock
+++ b/uv.lock
@@ -820,6 +820,7 @@ dev = [
     { name = "pytest-cov" },
     { name = "pytest-mock" },
     { name = "ruff" },
+    { name = "types-requests" },
 ]
 
 [package.metadata]
@@ -841,6 +842,7 @@ dev = [
     { name = "pytest-cov", specifier = "==6.0.0" },
     { name = "pytest-mock", specifier = ">=3.12" },
     { name = "ruff", specifier = ">=0.15.4" },
+    { name = "types-requests", specifier = ">=2.31" },
 ]
 
 [[package]]
@@ -1161,6 +1163,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c3/af/14b24e41977adb296d6bd1fb59402cf7d60ce364f90c890bd2ec65c43b5a/tomlkit-0.14.0.tar.gz", hash = "sha256:cf00efca415dbd57575befb1f6634c4f42d2d87dbba376128adb42c121b87064", size = 187167, upload-time = "2026-01-13T01:14:53.304Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b5/11/87d6d29fb5d237229d67973a6c9e06e048f01cf4994dee194ab0ea841814/tomlkit-0.14.0-py3-none-any.whl", hash = "sha256:592064ed85b40fa213469f81ac584f67a4f2992509a7c3ea2d632208623a3680", size = 39310, upload-time = "2026-01-13T01:14:51.965Z" },
+]
+
+[[package]]
+name = "types-requests"
+version = "2.32.4.20260107"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0f/f3/a0663907082280664d745929205a89d41dffb29e89a50f753af7d57d0a96/types_requests-2.32.4.20260107.tar.gz", hash = "sha256:018a11ac158f801bfa84857ddec1650750e393df8a004a8a9ae2a9bec6fcb24f", size = 23165, upload-time = "2026-01-07T03:20:54.091Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1c/12/709ea261f2bf91ef0a26a9eed20f2623227a8ed85610c1e54c5805692ecb/types_requests-2.32.4.20260107-py3-none-any.whl", hash = "sha256:b703fe72f8ce5b31ef031264fe9395cac8f46a04661a79f7ed31a80fb308730d", size = 20676, upload-time = "2026-01-07T03:20:52.929Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -23,12 +23,177 @@ wheels = [
 ]
 
 [[package]]
+name = "beautifulsoup4"
+version = "4.14.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "soupsieve" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b0/1c6a16426d389813b48d95e26898aff79abbde42ad353958ad95cc8c9b21/beautifulsoup4-4.14.3.tar.gz", hash = "sha256:6292b1c5186d356bba669ef9f7f051757099565ad9ada5dd630bd9de5fa7fb86", size = 627737, upload-time = "2025-11-30T15:08:26.084Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1a/39/47f9197bdd44df24d67ac8893641e16f386c984a0619ef2ee4c51fbbc019/beautifulsoup4-4.14.3-py3-none-any.whl", hash = "sha256:0918bfe44902e6ad8d57732ba310582e98da931428d231a5ecb9e7c703a735bb", size = 107721, upload-time = "2025-11-30T15:08:24.087Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.2.25"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/af/2d/7bf41579a8986e348fa033a31cdd0e4121114f6bce2457e8876010b092dd/certifi-2026.2.25.tar.gz", hash = "sha256:e887ab5cee78ea814d3472169153c2d12cd43b14bd03329a39a9c6e2e80bfba7", size = 155029, upload-time = "2026-02-25T02:54:17.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/3c/c17fb3ca2d9c3acff52e30b309f538586f9f5b9c9cf454f3845fc9af4881/certifi-2026.2.25-py3-none-any.whl", hash = "sha256:027692e4402ad994f1c42e52a4997a9763c646b73e4096e4d5d6db8af1d6f0fa", size = 153684, upload-time = "2026-02-25T02:54:15.766Z" },
+]
+
+[[package]]
+name = "cffi"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/4a/3dfd5f7850cbf0d06dc84ba9aa00db766b52ca38d8b86e3a38314d52498c/cffi-2.0.0-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:b4c854ef3adc177950a8dfc81a86f5115d2abd545751a304c5bcf2c2c7283cfe", size = 184344, upload-time = "2025-09-08T23:22:26.456Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/8b/f0e4c441227ba756aafbe78f117485b25bb26b1c059d01f137fa6d14896b/cffi-2.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2de9a304e27f7596cd03d16f1b7c72219bd944e99cc52b84d0145aefb07cbd3c", size = 180560, upload-time = "2025-09-08T23:22:28.197Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/b7/1200d354378ef52ec227395d95c2576330fd22a869f7a70e88e1447eb234/cffi-2.0.0-cp311-cp311-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:baf5215e0ab74c16e2dd324e8ec067ef59e41125d3eade2b863d294fd5035c92", size = 209613, upload-time = "2025-09-08T23:22:29.475Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/56/6033f5e86e8cc9bb629f0077ba71679508bdf54a9a5e112a3c0b91870332/cffi-2.0.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:730cacb21e1bdff3ce90babf007d0a0917cc3e6492f336c2f0134101e0944f93", size = 216476, upload-time = "2025-09-08T23:22:31.063Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/7f/55fecd70f7ece178db2f26128ec41430d8720f2d12ca97bf8f0a628207d5/cffi-2.0.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:6824f87845e3396029f3820c206e459ccc91760e8fa24422f8b0c3d1731cbec5", size = 203374, upload-time = "2025-09-08T23:22:32.507Z" },
+    { url = "https://files.pythonhosted.org/packages/84/ef/a7b77c8bdc0f77adc3b46888f1ad54be8f3b7821697a7b89126e829e676a/cffi-2.0.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:9de40a7b0323d889cf8d23d1ef214f565ab154443c42737dfe52ff82cf857664", size = 202597, upload-time = "2025-09-08T23:22:34.132Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/91/500d892b2bf36529a75b77958edfcd5ad8e2ce4064ce2ecfeab2125d72d1/cffi-2.0.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8941aaadaf67246224cee8c3803777eed332a19d909b47e29c9842ef1e79ac26", size = 215574, upload-time = "2025-09-08T23:22:35.443Z" },
+    { url = "https://files.pythonhosted.org/packages/44/64/58f6255b62b101093d5df22dcb752596066c7e89dd725e0afaed242a61be/cffi-2.0.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:a05d0c237b3349096d3981b727493e22147f934b20f6f125a3eba8f994bec4a9", size = 218971, upload-time = "2025-09-08T23:22:36.805Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/49/fa72cebe2fd8a55fbe14956f9970fe8eb1ac59e5df042f603ef7c8ba0adc/cffi-2.0.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:94698a9c5f91f9d138526b48fe26a199609544591f859c870d477351dc7b2414", size = 211972, upload-time = "2025-09-08T23:22:38.436Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/28/dd0967a76aab36731b6ebfe64dec4e981aff7e0608f60c2d46b46982607d/cffi-2.0.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:5fed36fccc0612a53f1d4d9a816b50a36702c28a2aa880cb8a122b3466638743", size = 217078, upload-time = "2025-09-08T23:22:39.776Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/c0/015b25184413d7ab0a410775fdb4a50fca20f5589b5dab1dbbfa3baad8ce/cffi-2.0.0-cp311-cp311-win32.whl", hash = "sha256:c649e3a33450ec82378822b3dad03cc228b8f5963c0c12fc3b1e0ab940f768a5", size = 172076, upload-time = "2025-09-08T23:22:40.95Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/8f/dc5531155e7070361eb1b7e4c1a9d896d0cb21c49f807a6c03fd63fc877e/cffi-2.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:66f011380d0e49ed280c789fbd08ff0d40968ee7b665575489afa95c98196ab5", size = 182820, upload-time = "2025-09-08T23:22:42.463Z" },
+    { url = "https://files.pythonhosted.org/packages/95/5c/1b493356429f9aecfd56bc171285a4c4ac8697f76e9bbbbb105e537853a1/cffi-2.0.0-cp311-cp311-win_arm64.whl", hash = "sha256:c6638687455baf640e37344fe26d37c404db8b80d037c3d29f58fe8d1c3b194d", size = 177635, upload-time = "2025-09-08T23:22:43.623Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/47/4f61023ea636104d4f16ab488e268b93008c3d0bb76893b1b31db1f96802/cffi-2.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6d02d6655b0e54f54c4ef0b94eb6be0607b70853c45ce98bd278dc7de718be5d", size = 185271, upload-time = "2025-09-08T23:22:44.795Z" },
+    { url = "https://files.pythonhosted.org/packages/df/a2/781b623f57358e360d62cdd7a8c681f074a71d445418a776eef0aadb4ab4/cffi-2.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8eca2a813c1cb7ad4fb74d368c2ffbbb4789d377ee5bb8df98373c2cc0dee76c", size = 181048, upload-time = "2025-09-08T23:22:45.938Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/df/a4f0fbd47331ceeba3d37c2e51e9dfc9722498becbeec2bd8bc856c9538a/cffi-2.0.0-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:21d1152871b019407d8ac3985f6775c079416c282e431a4da6afe7aefd2bccbe", size = 212529, upload-time = "2025-09-08T23:22:47.349Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/72/12b5f8d3865bf0f87cf1404d8c374e7487dcf097a1c91c436e72e6badd83/cffi-2.0.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b21e08af67b8a103c71a250401c78d5e0893beff75e28c53c98f4de42f774062", size = 220097, upload-time = "2025-09-08T23:22:48.677Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/95/7a135d52a50dfa7c882ab0ac17e8dc11cec9d55d2c18dda414c051c5e69e/cffi-2.0.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:1e3a615586f05fc4065a8b22b8152f0c1b00cdbc60596d187c2a74f9e3036e4e", size = 207983, upload-time = "2025-09-08T23:22:50.06Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/c8/15cb9ada8895957ea171c62dc78ff3e99159ee7adb13c0123c001a2546c1/cffi-2.0.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:81afed14892743bbe14dacb9e36d9e0e504cd204e0b165062c488942b9718037", size = 206519, upload-time = "2025-09-08T23:22:51.364Z" },
+    { url = "https://files.pythonhosted.org/packages/78/2d/7fa73dfa841b5ac06c7b8855cfc18622132e365f5b81d02230333ff26e9e/cffi-2.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3e17ed538242334bf70832644a32a7aae3d83b57567f9fd60a26257e992b79ba", size = 219572, upload-time = "2025-09-08T23:22:52.902Z" },
+    { url = "https://files.pythonhosted.org/packages/07/e0/267e57e387b4ca276b90f0434ff88b2c2241ad72b16d31836adddfd6031b/cffi-2.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3925dd22fa2b7699ed2617149842d2e6adde22b262fcbfada50e3d195e4b3a94", size = 222963, upload-time = "2025-09-08T23:22:54.518Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/75/1f2747525e06f53efbd878f4d03bac5b859cbc11c633d0fb81432d98a795/cffi-2.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2c8f814d84194c9ea681642fd164267891702542f028a15fc97d4674b6206187", size = 221361, upload-time = "2025-09-08T23:22:55.867Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/2b/2b6435f76bfeb6bbf055596976da087377ede68df465419d192acf00c437/cffi-2.0.0-cp312-cp312-win32.whl", hash = "sha256:da902562c3e9c550df360bfa53c035b2f241fed6d9aef119048073680ace4a18", size = 172932, upload-time = "2025-09-08T23:22:57.188Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/ed/13bd4418627013bec4ed6e54283b1959cf6db888048c7cf4b4c3b5b36002/cffi-2.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:da68248800ad6320861f129cd9c1bf96ca849a2771a59e0344e88681905916f5", size = 183557, upload-time = "2025-09-08T23:22:58.351Z" },
+    { url = "https://files.pythonhosted.org/packages/95/31/9f7f93ad2f8eff1dbc1c3656d7ca5bfd8fb52c9d786b4dcf19b2d02217fa/cffi-2.0.0-cp312-cp312-win_arm64.whl", hash = "sha256:4671d9dd5ec934cb9a73e7ee9676f9362aba54f7f34910956b84d727b0d73fb6", size = 177762, upload-time = "2025-09-08T23:22:59.668Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/8d/a0a47a0c9e413a658623d014e91e74a50cdd2c423f7ccfd44086ef767f90/cffi-2.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:00bdf7acc5f795150faa6957054fbbca2439db2f775ce831222b66f192f03beb", size = 185230, upload-time = "2025-09-08T23:23:00.879Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/d2/a6c0296814556c68ee32009d9c2ad4f85f2707cdecfd7727951ec228005d/cffi-2.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:45d5e886156860dc35862657e1494b9bae8dfa63bf56796f2fb56e1679fc0bca", size = 181043, upload-time = "2025-09-08T23:23:02.231Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/1e/d22cc63332bd59b06481ceaac49d6c507598642e2230f201649058a7e704/cffi-2.0.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:07b271772c100085dd28b74fa0cd81c8fb1a3ba18b21e03d7c27f3436a10606b", size = 212446, upload-time = "2025-09-08T23:23:03.472Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/f5/a2c23eb03b61a0b8747f211eb716446c826ad66818ddc7810cc2cc19b3f2/cffi-2.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d48a880098c96020b02d5a1f7d9251308510ce8858940e6fa99ece33f610838b", size = 220101, upload-time = "2025-09-08T23:23:04.792Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/7f/e6647792fc5850d634695bc0e6ab4111ae88e89981d35ac269956605feba/cffi-2.0.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f93fd8e5c8c0a4aa1f424d6173f14a892044054871c771f8566e4008eaa359d2", size = 207948, upload-time = "2025-09-08T23:23:06.127Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/1e/a5a1bd6f1fb30f22573f76533de12a00bf274abcdc55c8edab639078abb6/cffi-2.0.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:dd4f05f54a52fb558f1ba9f528228066954fee3ebe629fc1660d874d040ae5a3", size = 206422, upload-time = "2025-09-08T23:23:07.753Z" },
+    { url = "https://files.pythonhosted.org/packages/98/df/0a1755e750013a2081e863e7cd37e0cdd02664372c754e5560099eb7aa44/cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c8d3b5532fc71b7a77c09192b4a5a200ea992702734a2e9279a37f2478236f26", size = 219499, upload-time = "2025-09-08T23:23:09.648Z" },
+    { url = "https://files.pythonhosted.org/packages/50/e1/a969e687fcf9ea58e6e2a928ad5e2dd88cc12f6f0ab477e9971f2309b57c/cffi-2.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d9b29c1f0ae438d5ee9acb31cadee00a58c46cc9c0b2f9038c6b0b3470877a8c", size = 222928, upload-time = "2025-09-08T23:23:10.928Z" },
+    { url = "https://files.pythonhosted.org/packages/36/54/0362578dd2c9e557a28ac77698ed67323ed5b9775ca9d3fe73fe191bb5d8/cffi-2.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6d50360be4546678fc1b79ffe7a66265e28667840010348dd69a314145807a1b", size = 221302, upload-time = "2025-09-08T23:23:12.42Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/6d/bf9bda840d5f1dfdbf0feca87fbdb64a918a69bca42cfa0ba7b137c48cb8/cffi-2.0.0-cp313-cp313-win32.whl", hash = "sha256:74a03b9698e198d47562765773b4a8309919089150a0bb17d829ad7b44b60d27", size = 172909, upload-time = "2025-09-08T23:23:14.32Z" },
+    { url = "https://files.pythonhosted.org/packages/37/18/6519e1ee6f5a1e579e04b9ddb6f1676c17368a7aba48299c3759bbc3c8b3/cffi-2.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:19f705ada2530c1167abacb171925dd886168931e0a7b78f5bffcae5c6b5be75", size = 183402, upload-time = "2025-09-08T23:23:15.535Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/0e/02ceeec9a7d6ee63bb596121c2c8e9b3a9e150936f4fbef6ca1943e6137c/cffi-2.0.0-cp313-cp313-win_arm64.whl", hash = "sha256:256f80b80ca3853f90c21b23ee78cd008713787b1b1e93eae9f3d6a7134abd91", size = 177780, upload-time = "2025-09-08T23:23:16.761Z" },
+    { url = "https://files.pythonhosted.org/packages/92/c4/3ce07396253a83250ee98564f8d7e9789fab8e58858f35d07a9a2c78de9f/cffi-2.0.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:fc33c5141b55ed366cfaad382df24fe7dcbc686de5be719b207bb248e3053dc5", size = 185320, upload-time = "2025-09-08T23:23:18.087Z" },
+    { url = "https://files.pythonhosted.org/packages/59/dd/27e9fa567a23931c838c6b02d0764611c62290062a6d4e8ff7863daf9730/cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c654de545946e0db659b3400168c9ad31b5d29593291482c43e3564effbcee13", size = 181487, upload-time = "2025-09-08T23:23:19.622Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/43/0e822876f87ea8a4ef95442c3d766a06a51fc5298823f884ef87aaad168c/cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:24b6f81f1983e6df8db3adc38562c83f7d4a0c36162885ec7f7b77c7dcbec97b", size = 220049, upload-time = "2025-09-08T23:23:20.853Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/89/76799151d9c2d2d1ead63c2429da9ea9d7aac304603de0c6e8764e6e8e70/cffi-2.0.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:12873ca6cb9b0f0d3a0da705d6086fe911591737a59f28b7936bdfed27c0d47c", size = 207793, upload-time = "2025-09-08T23:23:22.08Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/dd/3465b14bb9e24ee24cb88c9e3730f6de63111fffe513492bf8c808a3547e/cffi-2.0.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:d9b97165e8aed9272a6bb17c01e3cc5871a594a446ebedc996e2397a1c1ea8ef", size = 206300, upload-time = "2025-09-08T23:23:23.314Z" },
+    { url = "https://files.pythonhosted.org/packages/47/d9/d83e293854571c877a92da46fdec39158f8d7e68da75bf73581225d28e90/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:afb8db5439b81cf9c9d0c80404b60c3cc9c3add93e114dcae767f1477cb53775", size = 219244, upload-time = "2025-09-08T23:23:24.541Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/0f/1f177e3683aead2bb00f7679a16451d302c436b5cbf2505f0ea8146ef59e/cffi-2.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:737fe7d37e1a1bffe70bd5754ea763a62a066dc5913ca57e957824b72a85e205", size = 222828, upload-time = "2025-09-08T23:23:26.143Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/0f/cafacebd4b040e3119dcb32fed8bdef8dfe94da653155f9d0b9dc660166e/cffi-2.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:38100abb9d1b1435bc4cc340bb4489635dc2f0da7456590877030c9b3d40b0c1", size = 220926, upload-time = "2025-09-08T23:23:27.873Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/aa/df335faa45b395396fcbc03de2dfcab242cd61a9900e914fe682a59170b1/cffi-2.0.0-cp314-cp314-win32.whl", hash = "sha256:087067fa8953339c723661eda6b54bc98c5625757ea62e95eb4898ad5e776e9f", size = 175328, upload-time = "2025-09-08T23:23:44.61Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/92/882c2d30831744296ce713f0feb4c1cd30f346ef747b530b5318715cc367/cffi-2.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:203a48d1fb583fc7d78a4c6655692963b860a417c0528492a6bc21f1aaefab25", size = 185650, upload-time = "2025-09-08T23:23:45.848Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/2c/98ece204b9d35a7366b5b2c6539c350313ca13932143e79dc133ba757104/cffi-2.0.0-cp314-cp314-win_arm64.whl", hash = "sha256:dbd5c7a25a7cb98f5ca55d258b103a2054f859a46ae11aaf23134f9cc0d356ad", size = 180687, upload-time = "2025-09-08T23:23:47.105Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/61/c768e4d548bfa607abcda77423448df8c471f25dbe64fb2ef6d555eae006/cffi-2.0.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:9a67fc9e8eb39039280526379fb3a70023d77caec1852002b4da7e8b270c4dd9", size = 188773, upload-time = "2025-09-08T23:23:29.347Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/ea/5f76bce7cf6fcd0ab1a1058b5af899bfbef198bea4d5686da88471ea0336/cffi-2.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7a66c7204d8869299919db4d5069a82f1561581af12b11b3c9f48c584eb8743d", size = 185013, upload-time = "2025-09-08T23:23:30.63Z" },
+    { url = "https://files.pythonhosted.org/packages/be/b4/c56878d0d1755cf9caa54ba71e5d049479c52f9e4afc230f06822162ab2f/cffi-2.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7cc09976e8b56f8cebd752f7113ad07752461f48a58cbba644139015ac24954c", size = 221593, upload-time = "2025-09-08T23:23:31.91Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/0d/eb704606dfe8033e7128df5e90fee946bbcb64a04fcdaa97321309004000/cffi-2.0.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:92b68146a71df78564e4ef48af17551a5ddd142e5190cdf2c5624d0c3ff5b2e8", size = 209354, upload-time = "2025-09-08T23:23:33.214Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/19/3c435d727b368ca475fb8742ab97c9cb13a0de600ce86f62eab7fa3eea60/cffi-2.0.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b1e74d11748e7e98e2f426ab176d4ed720a64412b6a15054378afdb71e0f37dc", size = 208480, upload-time = "2025-09-08T23:23:34.495Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/44/681604464ed9541673e486521497406fadcc15b5217c3e326b061696899a/cffi-2.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:28a3a209b96630bca57cce802da70c266eb08c6e97e5afd61a75611ee6c64592", size = 221584, upload-time = "2025-09-08T23:23:36.096Z" },
+    { url = "https://files.pythonhosted.org/packages/25/8e/342a504ff018a2825d395d44d63a767dd8ebc927ebda557fecdaca3ac33a/cffi-2.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7553fb2090d71822f02c629afe6042c299edf91ba1bf94951165613553984512", size = 224443, upload-time = "2025-09-08T23:23:37.328Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/5e/b666bacbbc60fbf415ba9988324a132c9a7a0448a9a8f125074671c0f2c3/cffi-2.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6c6c373cfc5c83a975506110d17457138c8c63016b563cc9ed6e056a82f13ce4", size = 223437, upload-time = "2025-09-08T23:23:38.945Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/1d/ec1a60bd1a10daa292d3cd6bb0b359a81607154fb8165f3ec95fe003b85c/cffi-2.0.0-cp314-cp314t-win32.whl", hash = "sha256:1fc9ea04857caf665289b7a75923f2c6ed559b8298a1b8c49e59f7dd95c8481e", size = 180487, upload-time = "2025-09-08T23:23:40.423Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/41/4c1168c74fac325c0c8156f04b6749c8b6a8f405bbf91413ba088359f60d/cffi-2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d68b6cef7827e8641e8ef16f4494edda8b36104d79773a334beaa1e3521430f6", size = 191726, upload-time = "2025-09-08T23:23:41.742Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/3a/dbeec9d1ee0844c679f6bb5d6ad4e9f198b1224f4e7a32825f47f6192b0c/cffi-2.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0a1527a803f0a659de1af2e1fd700213caba79377e27e4693648c2923da066f9", size = 184195, upload-time = "2025-09-08T23:23:43.004Z" },
+]
+
+[[package]]
 name = "cfgv"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/4e/b5/721b8799b04bf9afe054a3899c6cf4e880fcf8563cc71c15610242490a0c/cfgv-3.5.0.tar.gz", hash = "sha256:d5b1034354820651caa73ede66a6294d6e95c1b00acc5e9b098e917404669132", size = 7334, upload-time = "2025-11-19T20:55:51.612Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl", hash = "sha256:a8dc6b26ad22ff227d2634a65cb388215ce6cc96bbcc5cfde7641ae87e8dacc0", size = 7445, upload-time = "2025-11-19T20:55:50.744Z" },
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.4.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1d/35/02daf95b9cd686320bb622eb148792655c9412dbb9b67abb5694e5910a24/charset_normalizer-3.4.5.tar.gz", hash = "sha256:95adae7b6c42a6c5b5b559b1a99149f090a57128155daeea91732c8d970d8644", size = 134804, upload-time = "2026-03-06T06:03:19.46Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8f/9e/bcec3b22c64ecec47d39bf5167c2613efd41898c019dccd4183f6aa5d6a7/charset_normalizer-3.4.5-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:610f72c0ee565dfb8ae1241b666119582fdbfe7c0975c175be719f940e110694", size = 279531, upload-time = "2026-03-06T06:00:52.252Z" },
+    { url = "https://files.pythonhosted.org/packages/58/12/81fd25f7e7078ab5d1eedbb0fac44be4904ae3370a3bf4533c8f2d159acd/charset_normalizer-3.4.5-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:60d68e820af339df4ae8358c7a2e7596badeb61e544438e489035f9fbf3246a5", size = 188006, upload-time = "2026-03-06T06:00:53.8Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/6e/f2d30e8c27c1b0736a6520311982cf5286cfc7f6cac77d7bc1325e3a23f2/charset_normalizer-3.4.5-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:10b473fc8dca1c3ad8559985794815f06ca3fc71942c969129070f2c3cdf7281", size = 205085, upload-time = "2026-03-06T06:00:55.311Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/90/d12cefcb53b5931e2cf792a33718d7126efb116a320eaa0742c7059a95e4/charset_normalizer-3.4.5-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d4eb8ac7469b2a5d64b5b8c04f84d8bf3ad340f4514b98523805cbf46e3b3923", size = 200545, upload-time = "2026-03-06T06:00:56.532Z" },
+    { url = "https://files.pythonhosted.org/packages/03/f4/44d3b830a20e89ff82a3134912d9a1cf6084d64f3b95dcad40f74449a654/charset_normalizer-3.4.5-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5bcb3227c3d9aaf73eaaab1db7ccd80a8995c509ee9941e2aae060ca6e4e5d81", size = 193863, upload-time = "2026-03-06T06:00:57.823Z" },
+    { url = "https://files.pythonhosted.org/packages/25/4b/f212119c18a6320a9d4a730d1b4057875cdeabf21b3614f76549042ef8a8/charset_normalizer-3.4.5-cp311-cp311-manylinux_2_31_armv7l.whl", hash = "sha256:75ee9c1cce2911581a70a3c0919d8bccf5b1cbc9b0e5171400ec736b4b569497", size = 181827, upload-time = "2026-03-06T06:00:59.323Z" },
+    { url = "https://files.pythonhosted.org/packages/74/00/b26158e48b425a202a92965f8069e8a63d9af1481dfa206825d7f74d2a3c/charset_normalizer-3.4.5-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:1d1401945cb77787dbd3af2446ff2d75912327c4c3a1526ab7955ecf8600687c", size = 191085, upload-time = "2026-03-06T06:01:00.546Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/c2/1c1737bf6fd40335fe53d28fe49afd99ee4143cc57a845e99635ce0b9b6d/charset_normalizer-3.4.5-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:0a45e504f5e1be0bd385935a8e1507c442349ca36f511a47057a71c9d1d6ea9e", size = 190688, upload-time = "2026-03-06T06:01:02.479Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/3d/abb5c22dc2ef493cd56522f811246a63c5427c08f3e3e50ab663de27fcf4/charset_normalizer-3.4.5-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:e09f671a54ce70b79a1fc1dc6da3072b7ef7251fadb894ed92d9aa8218465a5f", size = 183077, upload-time = "2026-03-06T06:01:04.231Z" },
+    { url = "https://files.pythonhosted.org/packages/44/33/5298ad4d419a58e25b3508e87f2758d1442ff00c2471f8e0403dab8edad5/charset_normalizer-3.4.5-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:d01de5e768328646e6a3fa9e562706f8f6641708c115c62588aef2b941a4f88e", size = 206706, upload-time = "2026-03-06T06:01:05.773Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/17/51e7895ac0f87c3b91d276a449ef09f5532a7529818f59646d7a55089432/charset_normalizer-3.4.5-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:131716d6786ad5e3dc542f5cc6f397ba3339dc0fb87f87ac30e550e8987756af", size = 191665, upload-time = "2026-03-06T06:01:07.473Z" },
+    { url = "https://files.pythonhosted.org/packages/90/8f/cce9adf1883e98906dbae380d769b4852bb0fa0004bc7d7a2243418d3ea8/charset_normalizer-3.4.5-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:1a374cc0b88aa710e8865dc1bd6edb3743c59f27830f0293ab101e4cf3ce9f85", size = 201950, upload-time = "2026-03-06T06:01:08.973Z" },
+    { url = "https://files.pythonhosted.org/packages/08/ca/bce99cd5c397a52919e2769d126723f27a4c037130374c051c00470bcd38/charset_normalizer-3.4.5-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:d31f0d1671e1534e395f9eb84a68e0fb670e1edb1fe819a9d7f564ae3bc4e53f", size = 195830, upload-time = "2026-03-06T06:01:10.155Z" },
+    { url = "https://files.pythonhosted.org/packages/87/4f/2e3d023a06911f1281f97b8f036edc9872167036ca6f55cc874a0be6c12c/charset_normalizer-3.4.5-cp311-cp311-win32.whl", hash = "sha256:cace89841c0599d736d3d74a27bc5821288bb47c5441923277afc6059d7fbcb4", size = 132029, upload-time = "2026-03-06T06:01:11.706Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/1f/a853b73d386521fd44b7f67ded6b17b7b2367067d9106a5c4b44f9a34274/charset_normalizer-3.4.5-cp311-cp311-win_amd64.whl", hash = "sha256:f8102ae93c0bc863b1d41ea0f4499c20a83229f52ed870850892df555187154a", size = 142404, upload-time = "2026-03-06T06:01:12.865Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/10/dba36f76b71c38e9d391abe0fd8a5b818790e053c431adecfc98c35cd2a9/charset_normalizer-3.4.5-cp311-cp311-win_arm64.whl", hash = "sha256:ed98364e1c262cf5f9363c3eca8c2df37024f52a8fa1180a3610014f26eac51c", size = 132796, upload-time = "2026-03-06T06:01:14.106Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/b6/9ee9c1a608916ca5feae81a344dffbaa53b26b90be58cc2159e3332d44ec/charset_normalizer-3.4.5-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:ed97c282ee4f994ef814042423a529df9497e3c666dca19be1d4cd1129dc7ade", size = 280976, upload-time = "2026-03-06T06:01:15.276Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/d8/a54f7c0b96f1df3563e9190f04daf981e365a9b397eedfdfb5dbef7e5c6c/charset_normalizer-3.4.5-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0294916d6ccf2d069727d65973c3a1ca477d68708db25fd758dd28b0827cff54", size = 189356, upload-time = "2026-03-06T06:01:16.511Z" },
+    { url = "https://files.pythonhosted.org/packages/42/69/2bf7f76ce1446759a5787cb87d38f6a61eb47dbbdf035cfebf6347292a65/charset_normalizer-3.4.5-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:dc57a0baa3eeedd99fafaef7511b5a6ef4581494e8168ee086031744e2679467", size = 206369, upload-time = "2026-03-06T06:01:17.853Z" },
+    { url = "https://files.pythonhosted.org/packages/10/9c/949d1a46dab56b959d9a87272482195f1840b515a3380e39986989a893ae/charset_normalizer-3.4.5-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ed1a9a204f317ef879b32f9af507d47e49cd5e7f8e8d5d96358c98373314fc60", size = 203285, upload-time = "2026-03-06T06:01:19.473Z" },
+    { url = "https://files.pythonhosted.org/packages/67/5c/ae30362a88b4da237d71ea214a8c7eb915db3eec941adda511729ac25fa2/charset_normalizer-3.4.5-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7ad83b8f9379176c841f8865884f3514d905bcd2a9a3b210eaa446e7d2223e4d", size = 196274, upload-time = "2026-03-06T06:01:20.728Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/07/c9f2cb0e46cb6d64fdcc4f95953747b843bb2181bda678dc4e699b8f0f9a/charset_normalizer-3.4.5-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:a118e2e0b5ae6b0120d5efa5f866e58f2bb826067a646431da4d6a2bdae7950e", size = 184715, upload-time = "2026-03-06T06:01:22.194Z" },
+    { url = "https://files.pythonhosted.org/packages/36/64/6b0ca95c44fddf692cd06d642b28f63009d0ce325fad6e9b2b4d0ef86a52/charset_normalizer-3.4.5-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:754f96058e61a5e22e91483f823e07df16416ce76afa4ebf306f8e1d1296d43f", size = 193426, upload-time = "2026-03-06T06:01:23.795Z" },
+    { url = "https://files.pythonhosted.org/packages/50/bc/a730690d726403743795ca3f5bb2baf67838c5fea78236098f324b965e40/charset_normalizer-3.4.5-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:0c300cefd9b0970381a46394902cd18eaf2aa00163f999590ace991989dcd0fc", size = 191780, upload-time = "2026-03-06T06:01:25.053Z" },
+    { url = "https://files.pythonhosted.org/packages/97/4f/6c0bc9af68222b22951552d73df4532b5be6447cee32d58e7e8c74ecbb7b/charset_normalizer-3.4.5-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:c108f8619e504140569ee7de3f97d234f0fbae338a7f9f360455071ef9855a95", size = 185805, upload-time = "2026-03-06T06:01:26.294Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/b9/a523fb9b0ee90814b503452b2600e4cbc118cd68714d57041564886e7325/charset_normalizer-3.4.5-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:d1028de43596a315e2720a9849ee79007ab742c06ad8b45a50db8cdb7ed4a82a", size = 208342, upload-time = "2026-03-06T06:01:27.55Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/61/c59e761dee4464050713e50e27b58266cc8e209e518c0b378c1580c959ba/charset_normalizer-3.4.5-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:19092dde50335accf365cce21998a1c6dd8eafd42c7b226eb54b2747cdce2fac", size = 193661, upload-time = "2026-03-06T06:01:29.051Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/43/729fa30aad69783f755c5ad8649da17ee095311ca42024742701e202dc59/charset_normalizer-3.4.5-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:4354e401eb6dab9aed3c7b4030514328a6c748d05e1c3e19175008ca7de84fb1", size = 204819, upload-time = "2026-03-06T06:01:30.298Z" },
+    { url = "https://files.pythonhosted.org/packages/87/33/d9b442ce5a91b96fc0840455a9e49a611bbadae6122778d0a6a79683dd31/charset_normalizer-3.4.5-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a68766a3c58fde7f9aaa22b3786276f62ab2f594efb02d0a1421b6282e852e98", size = 198080, upload-time = "2026-03-06T06:01:31.478Z" },
+    { url = "https://files.pythonhosted.org/packages/56/5a/b8b5a23134978ee9885cee2d6995f4c27cc41f9baded0a9685eabc5338f0/charset_normalizer-3.4.5-cp312-cp312-win32.whl", hash = "sha256:1827734a5b308b65ac54e86a618de66f935a4f63a8a462ff1e19a6788d6c2262", size = 132630, upload-time = "2026-03-06T06:01:33.056Z" },
+    { url = "https://files.pythonhosted.org/packages/70/53/e44a4c07e8904500aec95865dc3f6464dc3586a039ef0df606eb3ac38e35/charset_normalizer-3.4.5-cp312-cp312-win_amd64.whl", hash = "sha256:728c6a963dfab66ef865f49286e45239384249672cd598576765acc2a640a636", size = 142856, upload-time = "2026-03-06T06:01:34.489Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/aa/c5628f7cad591b1cf45790b7a61483c3e36cf41349c98af7813c483fd6e8/charset_normalizer-3.4.5-cp312-cp312-win_arm64.whl", hash = "sha256:75dfd1afe0b1647449e852f4fb428195a7ed0588947218f7ba929f6538487f02", size = 132982, upload-time = "2026-03-06T06:01:35.641Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/48/9f34ec4bb24aa3fdba1890c1bddb97c8a4be1bd84ef5c42ac2352563ad05/charset_normalizer-3.4.5-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ac59c15e3f1465f722607800c68713f9fbc2f672b9eb649fe831da4019ae9b23", size = 280788, upload-time = "2026-03-06T06:01:37.126Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/09/6003e7ffeb90cc0560da893e3208396a44c210c5ee42efff539639def59b/charset_normalizer-3.4.5-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:165c7b21d19365464e8f70e5ce5e12524c58b48c78c1f5a57524603c1ab003f8", size = 188890, upload-time = "2026-03-06T06:01:38.73Z" },
+    { url = "https://files.pythonhosted.org/packages/42/1e/02706edf19e390680daa694d17e2b8eab4b5f7ac285e2a51168b4b22ee6b/charset_normalizer-3.4.5-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:28269983f25a4da0425743d0d257a2d6921ea7d9b83599d4039486ec5b9f911d", size = 206136, upload-time = "2026-03-06T06:01:40.016Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/87/942c3def1b37baf3cf786bad01249190f3ca3d5e63a84f831e704977de1f/charset_normalizer-3.4.5-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d27ce22ec453564770d29d03a9506d449efbb9fa13c00842262b2f6801c48cce", size = 202551, upload-time = "2026-03-06T06:01:41.522Z" },
+    { url = "https://files.pythonhosted.org/packages/94/0a/af49691938dfe175d71b8a929bd7e4ace2809c0c5134e28bc535660d5262/charset_normalizer-3.4.5-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0625665e4ebdddb553ab185de5db7054393af8879fb0c87bd5690d14379d6819", size = 195572, upload-time = "2026-03-06T06:01:43.208Z" },
+    { url = "https://files.pythonhosted.org/packages/20/ea/dfb1792a8050a8e694cfbde1570ff97ff74e48afd874152d38163d1df9ae/charset_normalizer-3.4.5-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:c23eb3263356d94858655b3e63f85ac5d50970c6e8febcdde7830209139cc37d", size = 184438, upload-time = "2026-03-06T06:01:44.755Z" },
+    { url = "https://files.pythonhosted.org/packages/72/12/c281e2067466e3ddd0595bfaea58a6946765ace5c72dfa3edc2f5f118026/charset_normalizer-3.4.5-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e6302ca4ae283deb0af68d2fbf467474b8b6aedcd3dab4db187e07f94c109763", size = 193035, upload-time = "2026-03-06T06:01:46.051Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/4f/3792c056e7708e10464bad0438a44708886fb8f92e3c3d29ec5e2d964d42/charset_normalizer-3.4.5-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:e51ae7d81c825761d941962450f50d041db028b7278e7b08930b4541b3e45cb9", size = 191340, upload-time = "2026-03-06T06:01:47.547Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/86/80ddba897127b5c7a9bccc481b0cd36c8fefa485d113262f0fe4332f0bf4/charset_normalizer-3.4.5-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:597d10dec876923e5c59e48dbd366e852eacb2b806029491d307daea6b917d7c", size = 185464, upload-time = "2026-03-06T06:01:48.764Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/00/b5eff85ba198faacab83e0e4b6f0648155f072278e3b392a82478f8b988b/charset_normalizer-3.4.5-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:5cffde4032a197bd3b42fd0b9509ec60fb70918d6970e4cc773f20fc9180ca67", size = 208014, upload-time = "2026-03-06T06:01:50.371Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/11/d36f70be01597fd30850dde8a1269ebc8efadd23ba5785808454f2389bde/charset_normalizer-3.4.5-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:2da4eedcb6338e2321e831a0165759c0c620e37f8cd044a263ff67493be8ffb3", size = 193297, upload-time = "2026-03-06T06:01:51.933Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/1d/259eb0a53d4910536c7c2abb9cb25f4153548efb42800c6a9456764649c0/charset_normalizer-3.4.5-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:65a126fb4b070d05340a84fc709dd9e7c75d9b063b610ece8a60197a291d0adf", size = 204321, upload-time = "2026-03-06T06:01:53.887Z" },
+    { url = "https://files.pythonhosted.org/packages/84/31/faa6c5b9d3688715e1ed1bb9d124c384fe2fc1633a409e503ffe1c6398c1/charset_normalizer-3.4.5-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:c7a80a9242963416bd81f99349d5f3fce1843c303bd404f204918b6d75a75fd6", size = 197509, upload-time = "2026-03-06T06:01:56.439Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/a5/c7d9dd1503ffc08950b3260f5d39ec2366dd08254f0900ecbcf3a6197c7c/charset_normalizer-3.4.5-cp313-cp313-win32.whl", hash = "sha256:f1d725b754e967e648046f00c4facc42d414840f5ccc670c5670f59f83693e4f", size = 132284, upload-time = "2026-03-06T06:01:57.812Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/0f/57072b253af40c8aa6636e6de7d75985624c1eb392815b2f934199340a89/charset_normalizer-3.4.5-cp313-cp313-win_amd64.whl", hash = "sha256:e37bd100d2c5d3ba35db9c7c5ba5a9228cbcffe5c4778dc824b164e5257813d7", size = 142630, upload-time = "2026-03-06T06:01:59.062Z" },
+    { url = "https://files.pythonhosted.org/packages/31/41/1c4b7cc9f13bd9d369ce3bc993e13d374ce25fa38a2663644283ecf422c1/charset_normalizer-3.4.5-cp313-cp313-win_arm64.whl", hash = "sha256:93b3b2cc5cf1b8743660ce77a4f45f3f6d1172068207c1defc779a36eea6bb36", size = 133254, upload-time = "2026-03-06T06:02:00.281Z" },
+    { url = "https://files.pythonhosted.org/packages/43/be/0f0fd9bb4a7fa4fb5067fb7d9ac693d4e928d306f80a0d02bde43a7c4aee/charset_normalizer-3.4.5-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:8197abe5ca1ffb7d91e78360f915eef5addff270f8a71c1fc5be24a56f3e4873", size = 280232, upload-time = "2026-03-06T06:02:01.508Z" },
+    { url = "https://files.pythonhosted.org/packages/28/02/983b5445e4bef49cd8c9da73a8e029f0825f39b74a06d201bfaa2e55142a/charset_normalizer-3.4.5-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a2aecdb364b8a1802afdc7f9327d55dad5366bc97d8502d0f5854e50712dbc5f", size = 189688, upload-time = "2026-03-06T06:02:02.857Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/88/152745c5166437687028027dc080e2daed6fe11cfa95a22f4602591c42db/charset_normalizer-3.4.5-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a66aa5022bf81ab4b1bebfb009db4fd68e0c6d4307a1ce5ef6a26e5878dfc9e4", size = 206833, upload-time = "2026-03-06T06:02:05.127Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/0f/ebc15c8b02af2f19be9678d6eed115feeeccc45ce1f4b098d986c13e8769/charset_normalizer-3.4.5-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d77f97e515688bd615c1d1f795d540f32542d514242067adcb8ef532504cb9ee", size = 202879, upload-time = "2026-03-06T06:02:06.446Z" },
+    { url = "https://files.pythonhosted.org/packages/38/9c/71336bff6934418dc8d1e8a1644176ac9088068bc571da612767619c97b3/charset_normalizer-3.4.5-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:01a1ed54b953303ca7e310fafe0fe347aab348bd81834a0bcd602eb538f89d66", size = 195764, upload-time = "2026-03-06T06:02:08.763Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/95/ce92fde4f98615661871bc282a856cf9b8a15f686ba0af012984660d480b/charset_normalizer-3.4.5-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:b2d37d78297b39a9eb9eb92c0f6df98c706467282055419df141389b23f93362", size = 183728, upload-time = "2026-03-06T06:02:10.137Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/e7/f5b4588d94e747ce45ae680f0f242bc2d98dbd4eccfab73e6160b6893893/charset_normalizer-3.4.5-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e71bbb595973622b817c042bd943c3f3667e9c9983ce3d205f973f486fec98a7", size = 192937, upload-time = "2026-03-06T06:02:11.663Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/29/9d94ed6b929bf9f48bf6ede6e7474576499f07c4c5e878fb186083622716/charset_normalizer-3.4.5-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:4cd966c2559f501c6fd69294d082c2934c8dd4719deb32c22961a5ac6db0df1d", size = 192040, upload-time = "2026-03-06T06:02:13.489Z" },
+    { url = "https://files.pythonhosted.org/packages/15/d2/1a093a1cf827957f9445f2fe7298bcc16f8fc5e05c1ed2ad1af0b239035e/charset_normalizer-3.4.5-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:d5e52d127045d6ae01a1e821acfad2f3a1866c54d0e837828538fabe8d9d1bd6", size = 184107, upload-time = "2026-03-06T06:02:14.83Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/7d/82068ce16bd36135df7b97f6333c5d808b94e01d4599a682e2337ed5fd14/charset_normalizer-3.4.5-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:30a2b1a48478c3428d047ed9690d57c23038dac838a87ad624c85c0a78ebeb39", size = 208310, upload-time = "2026-03-06T06:02:16.165Z" },
+    { url = "https://files.pythonhosted.org/packages/84/4e/4dfb52307bb6af4a5c9e73e482d171b81d36f522b21ccd28a49656baa680/charset_normalizer-3.4.5-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:d8ed79b8f6372ca4254955005830fd61c1ccdd8c0fac6603e2c145c61dd95db6", size = 192918, upload-time = "2026-03-06T06:02:18.144Z" },
+    { url = "https://files.pythonhosted.org/packages/08/a4/159ff7da662cf7201502ca89980b8f06acf3e887b278956646a8aeb178ab/charset_normalizer-3.4.5-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:c5af897b45fa606b12464ccbe0014bbf8c09191e0a66aab6aa9d5cf6e77e0c94", size = 204615, upload-time = "2026-03-06T06:02:19.821Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/62/0dd6172203cb6b429ffffc9935001fde42e5250d57f07b0c28c6046deb6b/charset_normalizer-3.4.5-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:1088345bcc93c58d8d8f3d783eca4a6e7a7752bbff26c3eee7e73c597c191c2e", size = 197784, upload-time = "2026-03-06T06:02:21.86Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/5e/1aab5cb737039b9c59e63627dc8bbc0d02562a14f831cc450e5f91d84ce1/charset_normalizer-3.4.5-cp314-cp314-win32.whl", hash = "sha256:ee57b926940ba00bca7ba7041e665cc956e55ef482f851b9b65acb20d867e7a2", size = 133009, upload-time = "2026-03-06T06:02:23.289Z" },
+    { url = "https://files.pythonhosted.org/packages/40/65/e7c6c77d7aaa4c0d7974f2e403e17f0ed2cb0fc135f77d686b916bf1eead/charset_normalizer-3.4.5-cp314-cp314-win_amd64.whl", hash = "sha256:4481e6da1830c8a1cc0b746b47f603b653dadb690bcd851d039ffaefe70533aa", size = 143511, upload-time = "2026-03-06T06:02:26.195Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/91/52b0841c71f152f563b8e072896c14e3d83b195c188b338d3cc2e582d1d4/charset_normalizer-3.4.5-cp314-cp314-win_arm64.whl", hash = "sha256:97ab7787092eb9b50fb47fa04f24c75b768a606af1bcba1957f07f128a7219e4", size = 133775, upload-time = "2026-03-06T06:02:27.473Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/60/3a621758945513adfd4db86827a5bafcc615f913dbd0b4c2ed64a65731be/charset_normalizer-3.4.5-py3-none-any.whl", hash = "sha256:9db5e3fcdcee89a78c04dffb3fe33c79f77bd741a624946db2591c81b2fc85b0", size = 55455, upload-time = "2026-03-06T06:03:17.827Z" },
 ]
 
 [[package]]
@@ -145,6 +310,27 @@ toml = [
 ]
 
 [[package]]
+name = "curl-cffi"
+version = "0.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "cffi" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4e/3d/f39ca1f8fdf14408888e7c25e15eed63eac5f47926e206fb93300d28378c/curl_cffi-0.13.0.tar.gz", hash = "sha256:62ecd90a382bd5023750e3606e0aa7cb1a3a8ba41c14270b8e5e149ebf72c5ca", size = 151303, upload-time = "2025-08-06T13:05:42.988Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/d1/acabfd460f1de26cad882e5ef344d9adde1507034528cb6f5698a2e6a2f1/curl_cffi-0.13.0-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:434cadbe8df2f08b2fc2c16dff2779fb40b984af99c06aa700af898e185bb9db", size = 5686337, upload-time = "2025-08-06T13:05:28.985Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/1c/cdb4fb2d16a0e9de068e0e5bc02094e105ce58a687ff30b4c6f88e25a057/curl_cffi-0.13.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:59afa877a9ae09efa04646a7d068eeea48915a95d9add0a29854e7781679fcd7", size = 2994613, upload-time = "2025-08-06T13:05:31.027Z" },
+    { url = "https://files.pythonhosted.org/packages/04/3e/fdf617c1ec18c3038b77065d484d7517bb30f8fb8847224eb1f601a4e8bc/curl_cffi-0.13.0-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d06ed389e45a7ca97b17c275dbedd3d6524560270e675c720e93a2018a766076", size = 7931353, upload-time = "2025-08-06T13:05:32.273Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/10/6f30c05d251cf03ddc2b9fd19880f3cab8c193255e733444a2df03b18944/curl_cffi-0.13.0-cp39-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b4e0de45ab3b7a835c72bd53640c2347415111b43421b5c7a1a0b18deae2e541", size = 7486378, upload-time = "2025-08-06T13:05:33.672Z" },
+    { url = "https://files.pythonhosted.org/packages/77/81/5bdb7dd0d669a817397b2e92193559bf66c3807f5848a48ad10cf02bf6c7/curl_cffi-0.13.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8eb4083371bbb94e9470d782de235fb5268bf43520de020c9e5e6be8f395443f", size = 8328585, upload-time = "2025-08-06T13:05:35.28Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/c1/df5c6b4cfad41c08442e0f727e449f4fb5a05f8aa564d1acac29062e9e8e/curl_cffi-0.13.0-cp39-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:28911b526e8cd4aa0e5e38401bfe6887e8093907272f1f67ca22e6beb2933a51", size = 8739831, upload-time = "2025-08-06T13:05:37.078Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/91/6dd1910a212f2e8eafe57877bcf97748eb24849e1511a266687546066b8a/curl_cffi-0.13.0-cp39-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:6d433ffcb455ab01dd0d7bde47109083aa38b59863aa183d29c668ae4c96bf8e", size = 8711908, upload-time = "2025-08-06T13:05:38.741Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/e4/15a253f9b4bf8d008c31e176c162d2704a7e0c5e24d35942f759df107b68/curl_cffi-0.13.0-cp39-abi3-win_amd64.whl", hash = "sha256:66a6b75ce971de9af64f1b6812e275f60b88880577bac47ef1fa19694fa21cd3", size = 1614510, upload-time = "2025-08-06T13:05:40.451Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/0f/9c5275f17ad6ff5be70edb8e0120fdc184a658c9577ca426d4230f654beb/curl_cffi-0.13.0-cp39-abi3-win_arm64.whl", hash = "sha256:d438a3b45244e874794bc4081dc1e356d2bb926dcc7021e5a8fef2e2105ef1d8", size = 1365753, upload-time = "2025-08-06T13:05:41.879Z" },
+]
+
+[[package]]
 name = "dill"
 version = "0.4.1"
 source = { registry = "https://pypi.org/simple" }
@@ -193,6 +379,15 @@ wheels = [
 ]
 
 [[package]]
+name = "frozendict"
+version = "2.4.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/90/b2/2a3d1374b7780999d3184e171e25439a8358c47b481f68be883c14086b4c/frozendict-2.4.7.tar.gz", hash = "sha256:e478fb2a1391a56c8a6e10cc97c4a9002b410ecd1ac28c18d780661762e271bd", size = 317082, upload-time = "2025-11-11T22:40:14.251Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/74/f94141b38a51a553efef7f510fc213894161ae49b88bffd037f8d2a7cb2f/frozendict-2.4.7-py3-none-any.whl", hash = "sha256:972af65924ea25cf5b4d9326d549e69a9a4918d8a76a9d3a7cd174d98b237550", size = 16264, upload-time = "2025-11-11T22:40:12.836Z" },
+]
+
+[[package]]
 name = "ib-insync"
 version = "0.9.86"
 source = { registry = "https://pypi.org/simple" }
@@ -212,6 +407,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/57/84/376a3b96e5a8d33a7aa2c5b3b31a4b3c364117184bf0b17418055f6ace66/identify-2.6.17.tar.gz", hash = "sha256:f816b0b596b204c9fdf076ded172322f2723cf958d02f9c3587504834c8ff04d", size = 99579, upload-time = "2026-03-01T20:04:12.702Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/40/66/71c1227dff78aaeb942fed29dd5651f2aec166cc7c9aeea3e8b26a539b7d/identify-2.6.17-py2.py3-none-any.whl", hash = "sha256:be5f8412d5ed4b20f2bd41a65f920990bdccaa6a4a18a08f1eefdcd0bdd885f0", size = 99382, upload-time = "2026-03-01T20:04:11.439Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.11"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
 ]
 
 [[package]]
@@ -313,6 +517,12 @@ sdist = { url = "https://files.pythonhosted.org/packages/e7/ff/0ffefdcac38932a54
 wheels = [
     { url = "https://files.pythonhosted.org/packages/27/1a/1f68f9ba0c207934b35b86a8ca3aad8395a3d6dd7921c0686e23853ff5a9/mccabe-0.7.0-py2.py3-none-any.whl", hash = "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e", size = 7350, upload-time = "2022-01-24T01:14:49.62Z" },
 ]
+
+[[package]]
+name = "multitasking"
+version = "0.0.12"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/17/0d/74f0293dfd7dcc3837746d0138cbedd60b31701ecc75caec7d3f281feba0/multitasking-0.0.12.tar.gz", hash = "sha256:2fba2fa8ed8c4b85e227c5dd7dc41c7d658de3b6f247927316175a57349b84d1", size = 19984, upload-time = "2025-07-20T21:27:51.636Z" }
 
 [[package]]
 name = "mypy"
@@ -562,6 +772,15 @@ wheels = [
 ]
 
 [[package]]
+name = "peewee"
+version = "4.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bd/a0/307e09edfae54f103d66b54d82fdfd22cfc25e733731c97173f4ec661fc3/peewee-4.0.1.tar.gz", hash = "sha256:beb1a173a52952a4d69197ca36408166740b2ced339c0e8159617c3fa1e1c4da", size = 700753, upload-time = "2026-03-01T17:26:56.125Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bf/99/0f8d9e46df9812ab31dadb07ba304c3ff6d6076bf19a67f4d046790be2e1/peewee-4.0.1-py3-none-any.whl", hash = "sha256:10afaa02c9f6d0f2dfe0f5b9007075c985eb141ab740a8831e37be2a61b3595c", size = 139369, upload-time = "2026-03-01T17:26:54.597Z" },
+]
+
+[[package]]
 name = "platformdirs"
 version = "4.9.2"
 source = { registry = "https://pypi.org/simple" }
@@ -587,6 +806,7 @@ dependencies = [
     { name = "ib-insync" },
     { name = "openpyxl" },
     { name = "pandas" },
+    { name = "yfinance" },
 ]
 
 [package.dev-dependencies]
@@ -607,6 +827,7 @@ requires-dist = [
     { name = "ib-insync", specifier = ">=0.9" },
     { name = "openpyxl", specifier = ">=3.1" },
     { name = "pandas", specifier = ">=2.2" },
+    { name = "yfinance", specifier = ">=0.2" },
 ]
 
 [package.metadata.requires-dev]
@@ -636,6 +857,30 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/40/f1/6d86a29246dfd2e9b6237f0b5823717f60cad94d47ddc26afa916d21f525/pre_commit-4.5.1.tar.gz", hash = "sha256:eb545fcff725875197837263e977ea257a402056661f09dae08e4b149b030a61", size = 198232, upload-time = "2025-12-16T21:14:33.552Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5d/19/fd3ef348460c80af7bb4669ea7926651d1f95c23ff2df18b9d24bab4f3fa/pre_commit-4.5.1-py2.py3-none-any.whl", hash = "sha256:3b3afd891e97337708c1674210f8eba659b52a38ea5f822ff142d10786221f77", size = 226437, upload-time = "2025-12-16T21:14:32.409Z" },
+]
+
+[[package]]
+name = "protobuf"
+version = "7.34.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f2/00/04a2ab36b70a52d0356852979e08b44edde0435f2115dc66e25f2100f3ab/protobuf-7.34.0.tar.gz", hash = "sha256:3871a3df67c710aaf7bb8d214cc997342e63ceebd940c8c7fc65c9b3d697591a", size = 454726, upload-time = "2026-02-27T00:30:25.421Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/c4/6322ab5c8f279c4c358bc14eb8aefc0550b97222a39f04eb3c1af7a830fa/protobuf-7.34.0-cp310-abi3-macosx_10_9_universal2.whl", hash = "sha256:8e329966799f2c271d5e05e236459fe1cbfdb8755aaa3b0914fa60947ddea408", size = 429248, upload-time = "2026-02-27T00:30:14.924Z" },
+    { url = "https://files.pythonhosted.org/packages/45/99/b029bbbc61e8937545da5b79aa405ab2d9cf307a728f8c9459ad60d7a481/protobuf-7.34.0-cp310-abi3-manylinux2014_aarch64.whl", hash = "sha256:9d7a5005fb96f3c1e64f397f91500b0eb371b28da81296ae73a6b08a5b76cdd6", size = 325753, upload-time = "2026-02-27T00:30:17.247Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/79/09f02671eb75b251c5550a1c48e7b3d4b0623efd7c95a15a50f6f9fc1e2e/protobuf-7.34.0-cp310-abi3-manylinux2014_s390x.whl", hash = "sha256:4a72a8ec94e7a9f7ef7fe818ed26d073305f347f8b3b5ba31e22f81fd85fca02", size = 340200, upload-time = "2026-02-27T00:30:18.672Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/57/89727baef7578897af5ed166735ceb315819f1c184da8c3441271dbcfde7/protobuf-7.34.0-cp310-abi3-manylinux2014_x86_64.whl", hash = "sha256:964cf977e07f479c0697964e83deda72bcbc75c3badab506fb061b352d991b01", size = 324268, upload-time = "2026-02-27T00:30:20.088Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/3e/38ff2ddee5cc946f575c9d8cc822e34bde205cf61acf8099ad88ef19d7d2/protobuf-7.34.0-cp310-abi3-win32.whl", hash = "sha256:f791ec509707a1d91bd02e07df157e75e4fb9fbdad12a81b7396201ec244e2e3", size = 426628, upload-time = "2026-02-27T00:30:21.555Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/71/7c32eaf34a61a1bae1b62a2ac4ffe09b8d1bb0cf93ad505f42040023db89/protobuf-7.34.0-cp310-abi3-win_amd64.whl", hash = "sha256:9f9079f1dde4e32342ecbd1c118d76367090d4aaa19da78230c38101c5b3dd40", size = 437901, upload-time = "2026-02-27T00:30:22.836Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/e7/14dc9366696dcb53a413449881743426ed289d687bcf3d5aee4726c32ebb/protobuf-7.34.0-py3-none-any.whl", hash = "sha256:e3b914dd77fa33fa06ab2baa97937746ab25695f389869afdf03e81f34e45dc7", size = 170716, upload-time = "2026-02-27T00:30:23.994Z" },
+]
+
+[[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
 ]
 
 [[package]]
@@ -734,6 +979,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pytz"
+version = "2026.1.post1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/56/db/b8721d71d945e6a8ac63c0fc900b2067181dbb50805958d4d4661cf7d277/pytz-2026.1.post1.tar.gz", hash = "sha256:3378dde6a0c3d26719182142c56e60c7f9af7e968076f31aae569d72a0358ee1", size = 321088, upload-time = "2026-03-03T07:47:50.683Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/99/781fe0c827be2742bcc775efefccb3b048a3a9c6ce9aec0cbf4a101677e5/pytz-2026.1.post1-py2.py3-none-any.whl", hash = "sha256:f2fd16142fda348286a75e1a524be810bb05d444e5a081f37f7affc635035f7a", size = 510489, upload-time = "2026-03-03T07:47:49.167Z" },
+]
+
+[[package]]
 name = "pyyaml"
 version = "6.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -789,6 +1043,21 @@ wheels = [
 ]
 
 [[package]]
+name = "requests"
+version = "2.32.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6", size = 64738, upload-time = "2025-08-18T20:46:00.542Z" },
+]
+
+[[package]]
 name = "ruff"
 version = "0.15.4"
 source = { registry = "https://pypi.org/simple" }
@@ -820,6 +1089,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "soupsieve"
+version = "2.8.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/ae/2d9c981590ed9999a0d91755b47fc74f74de286b0f5cee14c9269041e6c4/soupsieve-2.8.3.tar.gz", hash = "sha256:3267f1eeea4251fb42728b6dfb746edc9acaffc4a45b27e19450b676586e8349", size = 118627, upload-time = "2026-01-20T04:27:02.457Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/46/2c/1462b1d0a634697ae9e55b3cecdcb64788e8b7d63f54d923fcd0bb140aed/soupsieve-2.8.3-py3-none-any.whl", hash = "sha256:ed64f2ba4eebeab06cc4962affce381647455978ffc1e36bb79a545b91f45a95", size = 37016, upload-time = "2026-01-20T04:27:01.012Z" },
 ]
 
 [[package]]
@@ -904,6 +1182,15 @@ wheels = [
 ]
 
 [[package]]
+name = "urllib3"
+version = "2.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+]
+
+[[package]]
 name = "virtualenv"
 version = "21.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -916,4 +1203,86 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/2f/c9/18d4b36606d6091844daa3bd93cf7dc78e6f5da21d9f21d06c221104b684/virtualenv-21.1.0.tar.gz", hash = "sha256:1990a0188c8f16b6b9cf65c9183049007375b26aad415514d377ccacf1e4fb44", size = 5840471, upload-time = "2026-02-27T08:49:29.702Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/78/55/896b06bf93a49bec0f4ae2a6f1ed12bd05c8860744ac3a70eda041064e4d/virtualenv-21.1.0-py3-none-any.whl", hash = "sha256:164f5e14c5587d170cf98e60378eb91ea35bf037be313811905d3a24ea33cc07", size = 5825072, upload-time = "2026-02-27T08:49:27.516Z" },
+]
+
+[[package]]
+name = "websockets"
+version = "16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/04/24/4b2031d72e840ce4c1ccb255f693b15c334757fc50023e4db9537080b8c4/websockets-16.0.tar.gz", hash = "sha256:5f6261a5e56e8d5c42a4497b364ea24d94d9563e8fbd44e78ac40879c60179b5", size = 179346, upload-time = "2026-01-10T09:23:47.181Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/db/de907251b4ff46ae804ad0409809504153b3f30984daf82a1d84a9875830/websockets-16.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:31a52addea25187bde0797a97d6fc3d2f92b6f72a9370792d65a6e84615ac8a8", size = 177340, upload-time = "2026-01-10T09:22:34.539Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/fa/abe89019d8d8815c8781e90d697dec52523fb8ebe308bf11664e8de1877e/websockets-16.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:417b28978cdccab24f46400586d128366313e8a96312e4b9362a4af504f3bbad", size = 175022, upload-time = "2026-01-10T09:22:36.332Z" },
+    { url = "https://files.pythonhosted.org/packages/58/5d/88ea17ed1ded2079358b40d31d48abe90a73c9e5819dbcde1606e991e2ad/websockets-16.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:af80d74d4edfa3cb9ed973a0a5ba2b2a549371f8a741e0800cb07becdd20f23d", size = 175319, upload-time = "2026-01-10T09:22:37.602Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/ae/0ee92b33087a33632f37a635e11e1d99d429d3d323329675a6022312aac2/websockets-16.0-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:08d7af67b64d29823fed316505a89b86705f2b7981c07848fb5e3ea3020c1abe", size = 184631, upload-time = "2026-01-10T09:22:38.789Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/c5/27178df583b6c5b31b29f526ba2da5e2f864ecc79c99dae630a85d68c304/websockets-16.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7be95cfb0a4dae143eaed2bcba8ac23f4892d8971311f1b06f3c6b78952ee70b", size = 185870, upload-time = "2026-01-10T09:22:39.893Z" },
+    { url = "https://files.pythonhosted.org/packages/87/05/536652aa84ddc1c018dbb7e2c4cbcd0db884580bf8e95aece7593fde526f/websockets-16.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d6297ce39ce5c2e6feb13c1a996a2ded3b6832155fcfc920265c76f24c7cceb5", size = 185361, upload-time = "2026-01-10T09:22:41.016Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/e2/d5332c90da12b1e01f06fb1b85c50cfc489783076547415bf9f0a659ec19/websockets-16.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:1c1b30e4f497b0b354057f3467f56244c603a79c0d1dafce1d16c283c25f6e64", size = 184615, upload-time = "2026-01-10T09:22:42.442Z" },
+    { url = "https://files.pythonhosted.org/packages/77/fb/d3f9576691cae9253b51555f841bc6600bf0a983a461c79500ace5a5b364/websockets-16.0-cp311-cp311-win32.whl", hash = "sha256:5f451484aeb5cafee1ccf789b1b66f535409d038c56966d6101740c1614b86c6", size = 178246, upload-time = "2026-01-10T09:22:43.654Z" },
+    { url = "https://files.pythonhosted.org/packages/54/67/eaff76b3dbaf18dcddabc3b8c1dba50b483761cccff67793897945b37408/websockets-16.0-cp311-cp311-win_amd64.whl", hash = "sha256:8d7f0659570eefb578dacde98e24fb60af35350193e4f56e11190787bee77dac", size = 178684, upload-time = "2026-01-10T09:22:44.941Z" },
+    { url = "https://files.pythonhosted.org/packages/84/7b/bac442e6b96c9d25092695578dda82403c77936104b5682307bd4deb1ad4/websockets-16.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:71c989cbf3254fbd5e84d3bff31e4da39c43f884e64f2551d14bb3c186230f00", size = 177365, upload-time = "2026-01-10T09:22:46.787Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/fe/136ccece61bd690d9c1f715baaeefd953bb2360134de73519d5df19d29ca/websockets-16.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:8b6e209ffee39ff1b6d0fa7bfef6de950c60dfb91b8fcead17da4ee539121a79", size = 175038, upload-time = "2026-01-10T09:22:47.999Z" },
+    { url = "https://files.pythonhosted.org/packages/40/1e/9771421ac2286eaab95b8575b0cb701ae3663abf8b5e1f64f1fd90d0a673/websockets-16.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:86890e837d61574c92a97496d590968b23c2ef0aeb8a9bc9421d174cd378ae39", size = 175328, upload-time = "2026-01-10T09:22:49.809Z" },
+    { url = "https://files.pythonhosted.org/packages/18/29/71729b4671f21e1eaa5d6573031ab810ad2936c8175f03f97f3ff164c802/websockets-16.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9b5aca38b67492ef518a8ab76851862488a478602229112c4b0d58d63a7a4d5c", size = 184915, upload-time = "2026-01-10T09:22:51.071Z" },
+    { url = "https://files.pythonhosted.org/packages/97/bb/21c36b7dbbafc85d2d480cd65df02a1dc93bf76d97147605a8e27ff9409d/websockets-16.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e0334872c0a37b606418ac52f6ab9cfd17317ac26365f7f65e203e2d0d0d359f", size = 186152, upload-time = "2026-01-10T09:22:52.224Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/34/9bf8df0c0cf88fa7bfe36678dc7b02970c9a7d5e065a3099292db87b1be2/websockets-16.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a0b31e0b424cc6b5a04b8838bbaec1688834b2383256688cf47eb97412531da1", size = 185583, upload-time = "2026-01-10T09:22:53.443Z" },
+    { url = "https://files.pythonhosted.org/packages/47/88/4dd516068e1a3d6ab3c7c183288404cd424a9a02d585efbac226cb61ff2d/websockets-16.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:485c49116d0af10ac698623c513c1cc01c9446c058a4e61e3bf6c19dff7335a2", size = 184880, upload-time = "2026-01-10T09:22:55.033Z" },
+    { url = "https://files.pythonhosted.org/packages/91/d6/7d4553ad4bf1c0421e1ebd4b18de5d9098383b5caa1d937b63df8d04b565/websockets-16.0-cp312-cp312-win32.whl", hash = "sha256:eaded469f5e5b7294e2bdca0ab06becb6756ea86894a47806456089298813c89", size = 178261, upload-time = "2026-01-10T09:22:56.251Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/f0/f3a17365441ed1c27f850a80b2bc680a0fa9505d733fe152fdf5e98c1c0b/websockets-16.0-cp312-cp312-win_amd64.whl", hash = "sha256:5569417dc80977fc8c2d43a86f78e0a5a22fee17565d78621b6bb264a115d4ea", size = 178693, upload-time = "2026-01-10T09:22:57.478Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/9c/baa8456050d1c1b08dd0ec7346026668cbc6f145ab4e314d707bb845bf0d/websockets-16.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:878b336ac47938b474c8f982ac2f7266a540adc3fa4ad74ae96fea9823a02cc9", size = 177364, upload-time = "2026-01-10T09:22:59.333Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/0c/8811fc53e9bcff68fe7de2bcbe75116a8d959ac699a3200f4847a8925210/websockets-16.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:52a0fec0e6c8d9a784c2c78276a48a2bdf099e4ccc2a4cad53b27718dbfd0230", size = 175039, upload-time = "2026-01-10T09:23:01.171Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/82/39a5f910cb99ec0b59e482971238c845af9220d3ab9fa76dd9162cda9d62/websockets-16.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e6578ed5b6981005df1860a56e3617f14a6c307e6a71b4fff8c48fdc50f3ed2c", size = 175323, upload-time = "2026-01-10T09:23:02.341Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/28/0a25ee5342eb5d5f297d992a77e56892ecb65e7854c7898fb7d35e9b33bd/websockets-16.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:95724e638f0f9c350bb1c2b0a7ad0e83d9cc0c9259f3ea94e40d7b02a2179ae5", size = 184975, upload-time = "2026-01-10T09:23:03.756Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/66/27ea52741752f5107c2e41fda05e8395a682a1e11c4e592a809a90c6a506/websockets-16.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c0204dc62a89dc9d50d682412c10b3542d748260d743500a85c13cd1ee4bde82", size = 186203, upload-time = "2026-01-10T09:23:05.01Z" },
+    { url = "https://files.pythonhosted.org/packages/37/e5/8e32857371406a757816a2b471939d51c463509be73fa538216ea52b792a/websockets-16.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:52ac480f44d32970d66763115edea932f1c5b1312de36df06d6b219f6741eed8", size = 185653, upload-time = "2026-01-10T09:23:06.301Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/67/f926bac29882894669368dc73f4da900fcdf47955d0a0185d60103df5737/websockets-16.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6e5a82b677f8f6f59e8dfc34ec06ca6b5b48bc4fcda346acd093694cc2c24d8f", size = 184920, upload-time = "2026-01-10T09:23:07.492Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/a1/3d6ccdcd125b0a42a311bcd15a7f705d688f73b2a22d8cf1c0875d35d34a/websockets-16.0-cp313-cp313-win32.whl", hash = "sha256:abf050a199613f64c886ea10f38b47770a65154dc37181bfaff70c160f45315a", size = 178255, upload-time = "2026-01-10T09:23:09.245Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/ae/90366304d7c2ce80f9b826096a9e9048b4bb760e44d3b873bb272cba696b/websockets-16.0-cp313-cp313-win_amd64.whl", hash = "sha256:3425ac5cf448801335d6fdc7ae1eb22072055417a96cc6b31b3861f455fbc156", size = 178689, upload-time = "2026-01-10T09:23:10.483Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/1d/e88022630271f5bd349ed82417136281931e558d628dd52c4d8621b4a0b2/websockets-16.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:8cc451a50f2aee53042ac52d2d053d08bf89bcb31ae799cb4487587661c038a0", size = 177406, upload-time = "2026-01-10T09:23:12.178Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/78/e63be1bf0724eeb4616efb1ae1c9044f7c3953b7957799abb5915bffd38e/websockets-16.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:daa3b6ff70a9241cf6c7fc9e949d41232d9d7d26fd3522b1ad2b4d62487e9904", size = 175085, upload-time = "2026-01-10T09:23:13.511Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/f4/d3c9220d818ee955ae390cf319a7c7a467beceb24f05ee7aaaa2414345ba/websockets-16.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:fd3cb4adb94a2a6e2b7c0d8d05cb94e6f1c81a0cf9dc2694fb65c7e8d94c42e4", size = 175328, upload-time = "2026-01-10T09:23:14.727Z" },
+    { url = "https://files.pythonhosted.org/packages/63/bc/d3e208028de777087e6fb2b122051a6ff7bbcca0d6df9d9c2bf1dd869ae9/websockets-16.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:781caf5e8eee67f663126490c2f96f40906594cb86b408a703630f95550a8c3e", size = 185044, upload-time = "2026-01-10T09:23:15.939Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/6e/9a0927ac24bd33a0a9af834d89e0abc7cfd8e13bed17a86407a66773cc0e/websockets-16.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:caab51a72c51973ca21fa8a18bd8165e1a0183f1ac7066a182ff27107b71e1a4", size = 186279, upload-time = "2026-01-10T09:23:17.148Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/ca/bf1c68440d7a868180e11be653c85959502efd3a709323230314fda6e0b3/websockets-16.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:19c4dc84098e523fd63711e563077d39e90ec6702aff4b5d9e344a60cb3c0cb1", size = 185711, upload-time = "2026-01-10T09:23:18.372Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/f8/fdc34643a989561f217bb477cbc47a3a07212cbda91c0e4389c43c296ebf/websockets-16.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:a5e18a238a2b2249c9a9235466b90e96ae4795672598a58772dd806edc7ac6d3", size = 184982, upload-time = "2026-01-10T09:23:19.652Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/d1/574fa27e233764dbac9c52730d63fcf2823b16f0856b3329fc6268d6ae4f/websockets-16.0-cp314-cp314-win32.whl", hash = "sha256:a069d734c4a043182729edd3e9f247c3b2a4035415a9172fd0f1b71658a320a8", size = 177915, upload-time = "2026-01-10T09:23:21.458Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/f1/ae6b937bf3126b5134ce1f482365fde31a357c784ac51852978768b5eff4/websockets-16.0-cp314-cp314-win_amd64.whl", hash = "sha256:c0ee0e63f23914732c6d7e0cce24915c48f3f1512ec1d079ed01fc629dab269d", size = 178381, upload-time = "2026-01-10T09:23:22.715Z" },
+    { url = "https://files.pythonhosted.org/packages/06/9b/f791d1db48403e1f0a27577a6beb37afae94254a8c6f08be4a23e4930bc0/websockets-16.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:a35539cacc3febb22b8f4d4a99cc79b104226a756aa7400adc722e83b0d03244", size = 177737, upload-time = "2026-01-10T09:23:24.523Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/40/53ad02341fa33b3ce489023f635367a4ac98b73570102ad2cdd770dacc9a/websockets-16.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:b784ca5de850f4ce93ec85d3269d24d4c82f22b7212023c974c401d4980ebc5e", size = 175268, upload-time = "2026-01-10T09:23:25.781Z" },
+    { url = "https://files.pythonhosted.org/packages/74/9b/6158d4e459b984f949dcbbb0c5d270154c7618e11c01029b9bbd1bb4c4f9/websockets-16.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:569d01a4e7fba956c5ae4fc988f0d4e187900f5497ce46339c996dbf24f17641", size = 175486, upload-time = "2026-01-10T09:23:27.033Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/2d/7583b30208b639c8090206f95073646c2c9ffd66f44df967981a64f849ad/websockets-16.0-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:50f23cdd8343b984957e4077839841146f67a3d31ab0d00e6b824e74c5b2f6e8", size = 185331, upload-time = "2026-01-10T09:23:28.259Z" },
+    { url = "https://files.pythonhosted.org/packages/45/b0/cce3784eb519b7b5ad680d14b9673a31ab8dcb7aad8b64d81709d2430aa8/websockets-16.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:152284a83a00c59b759697b7f9e9cddf4e3c7861dd0d964b472b70f78f89e80e", size = 186501, upload-time = "2026-01-10T09:23:29.449Z" },
+    { url = "https://files.pythonhosted.org/packages/19/60/b8ebe4c7e89fb5f6cdf080623c9d92789a53636950f7abacfc33fe2b3135/websockets-16.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:bc59589ab64b0022385f429b94697348a6a234e8ce22544e3681b2e9331b5944", size = 186062, upload-time = "2026-01-10T09:23:31.368Z" },
+    { url = "https://files.pythonhosted.org/packages/88/a8/a080593f89b0138b6cba1b28f8df5673b5506f72879322288b031337c0b8/websockets-16.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:32da954ffa2814258030e5a57bc73a3635463238e797c7375dc8091327434206", size = 185356, upload-time = "2026-01-10T09:23:32.627Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/b6/b9afed2afadddaf5ebb2afa801abf4b0868f42f8539bfe4b071b5266c9fe/websockets-16.0-cp314-cp314t-win32.whl", hash = "sha256:5a4b4cc550cb665dd8a47f868c8d04c8230f857363ad3c9caf7a0c3bf8c61ca6", size = 178085, upload-time = "2026-01-10T09:23:33.816Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/3e/28135a24e384493fa804216b79a6a6759a38cc4ff59118787b9fb693df93/websockets-16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b14dc141ed6d2dde437cddb216004bcac6a1df0935d79656387bd41632ba0bbd", size = 178531, upload-time = "2026-01-10T09:23:35.016Z" },
+    { url = "https://files.pythonhosted.org/packages/72/07/c98a68571dcf256e74f1f816b8cc5eae6eb2d3d5cfa44d37f801619d9166/websockets-16.0-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:349f83cd6c9a415428ee1005cadb5c2c56f4389bc06a9af16103c3bc3dcc8b7d", size = 174947, upload-time = "2026-01-10T09:23:36.166Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/52/93e166a81e0305b33fe416338be92ae863563fe7bce446b0f687b9df5aea/websockets-16.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:4a1aba3340a8dca8db6eb5a7986157f52eb9e436b74813764241981ca4888f03", size = 175260, upload-time = "2026-01-10T09:23:37.409Z" },
+    { url = "https://files.pythonhosted.org/packages/56/0c/2dbf513bafd24889d33de2ff0368190a0e69f37bcfa19009ef819fe4d507/websockets-16.0-pp311-pypy311_pp73-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:f4a32d1bd841d4bcbffdcb3d2ce50c09c3909fbead375ab28d0181af89fd04da", size = 176071, upload-time = "2026-01-10T09:23:39.158Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/8f/aea9c71cc92bf9b6cc0f7f70df8f0b420636b6c96ef4feee1e16f80f75dd/websockets-16.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0298d07ee155e2e9fda5be8a9042200dd2e3bb0b8a38482156576f863a9d457c", size = 176968, upload-time = "2026-01-10T09:23:41.031Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/3f/f70e03f40ffc9a30d817eef7da1be72ee4956ba8d7255c399a01b135902a/websockets-16.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:a653aea902e0324b52f1613332ddf50b00c06fdaf7e92624fbf8c77c78fa5767", size = 178735, upload-time = "2026-01-10T09:23:42.259Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", size = 171598, upload-time = "2026-01-10T09:23:45.395Z" },
+]
+
+[[package]]
+name = "yfinance"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "beautifulsoup4" },
+    { name = "curl-cffi" },
+    { name = "frozendict" },
+    { name = "multitasking" },
+    { name = "numpy" },
+    { name = "pandas" },
+    { name = "peewee" },
+    { name = "platformdirs" },
+    { name = "protobuf" },
+    { name = "pytz" },
+    { name = "requests" },
+    { name = "websockets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c9/1b/431d0ebd6a1e9deaffc8627cc4d26fd869841f31a1429cab7443eced0766/yfinance-1.2.0.tar.gz", hash = "sha256:80cec643eb983330ca63debab1b5492334fa1e6338d82cb17dd4e7b95079cfab", size = 140501, upload-time = "2026-02-16T19:52:34.368Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/60/462859de757ac56830824da7e8cf314b8b0321af5853df867c84cd6c2128/yfinance-1.2.0-py2.py3-none-any.whl", hash = "sha256:1c27d1ebfc6275f476721cc6dba035a49d0cf9a806d6aa1785c9e10cf8a610d8", size = 130247, upload-time = "2026-02-16T19:52:33.109Z" },
 ]


### PR DESCRIPTION
- yFinance integration for US and UK equities; sector mapped to the 13-sector taxonomy
- **SGX fallback chain** for `.SI` tickers: yFinance → SGX public API (`api.sgx.com/securities/v1.1`) → `data/sgx_sectors.csv` → `Unclassified`
- **SG REIT override**: after sector lookup completes (any layer), if the security is classified as a REIT by any data source or has "REIT" in its name, reclassify to the `REITs` sector, overriding yFinance, SGX API, or CSV classification if they assigned it to Financials or Real Estate
- **ETF look-through** (preferred): map ETF underlying holdings to their sectors proportionally; fall back to `ETF Broad Market` if look-through data is unavailable; record `etf_lookthrough: true/false` on each holding
- **FX rate fetch**: at run start, fetch `GBPSGD=X` and `USDSGD=X` via yFinance and cache for the duration of the run
- In-memory caching layer to avoid redundant API calls during a single run
- Graceful handling of missing or unrecognised tickers (tag as `Unclassified`, do not raise)
- Unit tests with mocked API responses; SGX fallback chain tested at each layer

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Holdings now include sector classification and an ETF look-through flag.
  * ETF positions analyzed for underlying sector exposure; dominant sector used when available.
  * Exchange rates (USD/GBP/EUR/JPY) are fetched and cached to support conversions.
  * Per-run caching reduces repeated external lookups.

* **Bug Fixes**
  * Tightened error handling for data import and brokerage connections with safer fallbacks.

* **Tests**
  * Added comprehensive tests for sector enrichment, FX fetching, caching, and ETF handling.

* **Documentation**
  * Updated project notes describing ETF look-through goals and acceptance criteria.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->